### PR TITLE
compat: fix typo in compat tool that produces "TypeError: 'int' object is not callable"

### DIFF
--- a/src/compat/authcompat_EnvironmentFile.py
+++ b/src/compat/authcompat_EnvironmentFile.py
@@ -204,7 +204,7 @@ class EnvironmentFile:
                 i = value.find("\\", i)
                 if i < 0:
                     break
-                if i + 1 >= length(value):
+                if i + 1 >= len(value):
                     value = value[0:i]
                     break
 


### PR DESCRIPTION
Resolves:
https://github.com/pbrezina/authselect/issues/92