### PR TITLE
new option: with-session-pam-env

### DIFF
--- a/profiles/minimal/README
+++ b/profiles/minimal/README
@@ -35,6 +35,10 @@ with-pamaccess::
 with-altfiles::
     Use nss_altfiles for passwd and group nsswitch databases.
 
+with-session-pam-env::
+    Enable pam_env sessions module.  Useful for setting environment variables
+    for all users via /etc/security/pam_env.conf.
+
 without-nullok::
     Do not add nullok parameter to pam_unix.
 

--- a/profiles/minimal/password-auth
+++ b/profiles/minimal/password-auth
@@ -13,6 +13,7 @@ password    requisite                                    pam_pwquality.so try_fi
 password    sufficient                                   pam_unix.so sha512 shadow {if not "without-nullok":nullok} try_first_pass use_authtok
 password    required                                     pam_deny.so
 
+session     optional                                     pam_env.so                                            {include if "with-session-pam-env"}
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}

--- a/profiles/minimal/system-auth
+++ b/profiles/minimal/system-auth
@@ -13,6 +13,7 @@ password    requisite                                    pam_pwquality.so try_fi
 password    sufficient                                   pam_unix.so sha512 shadow {if not "without-nullok":nullok} try_first_pass use_authtok
 password    required                                     pam_deny.so
 
+session     optional                                     pam_env.so                                            {include if "with-session-pam-env"}
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}

--- a/profiles/nis/README
+++ b/profiles/nis/README
@@ -44,6 +44,10 @@ with-nispwquality::
     for NIS users as well as local users during password change. Without this
     option only local users passwords are checked.
 
+with-session-pam-env::
+    Enable pam_env sessions module.  Useful for setting environment variables
+    for all users via /etc/security/pam_env.conf.
+
 without-nullok::
     Do not add nullok parameter to pam_unix.
 

--- a/profiles/nis/fingerprint-auth
+++ b/profiles/nis/fingerprint-auth
@@ -11,6 +11,7 @@ account     required                                     pam_unix.so broken_shad
 
 password    required                                     pam_deny.so
 
+session     optional                                     pam_env.so                                            {include if "with-session-pam-env"}
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}

--- a/profiles/nis/password-auth
+++ b/profiles/nis/password-auth
@@ -15,6 +15,7 @@ password    requisite                                    pam_pwquality.so try_fi
 password    sufficient                                   pam_unix.so sha512 shadow {if not "without-nullok":nullok} try_first_pass use_authtok nis
 password    required                                     pam_deny.so
 
+session     optional                                     pam_env.so                                            {include if "with-session-pam-env"}
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                  {include if "with-ecryptfs"}

--- a/profiles/nis/system-auth
+++ b/profiles/nis/system-auth
@@ -16,6 +16,7 @@ password    requisite                                    pam_pwquality.so try_fi
 password    sufficient                                   pam_unix.so sha512 shadow {if not "without-nullok":nullok} try_first_pass use_authtok nis
 password    required                                     pam_deny.so
 
+session     optional                                     pam_env.so                                            {include if "with-session-pam-env"}
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}

--- a/profiles/sssd/README
+++ b/profiles/sssd/README
@@ -83,6 +83,10 @@ with-files-access-provider::
     system accounts (as defined by pam_usertype, including root) will be
     able to log in.
 
+with-session-pam-env::
+    Enable pam_env sessions module.  Useful for setting environment variables
+    for all users via /etc/security/pam_env.conf.
+
 without-nullok::
     Do not add nullok parameter to pam_unix.
 

--- a/profiles/sssd/fingerprint-auth
+++ b/profiles/sssd/fingerprint-auth
@@ -16,6 +16,7 @@ account     required                                     pam_permit.so
 
 password    required                                     pam_deny.so
 
+session     optional                                     pam_env.so                                            {include if "with-session-pam-env"}
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}

--- a/profiles/sssd/password-auth
+++ b/profiles/sssd/password-auth
@@ -25,6 +25,7 @@ password    sufficient                                   pam_unix.so sha512 shad
 password    sufficient                                   pam_sss.so use_authtok
 password    required                                     pam_deny.so
 
+session     optional                                     pam_env.so                                            {include if "with-session-pam-env"}
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}

--- a/profiles/sssd/smartcard-auth
+++ b/profiles/sssd/smartcard-auth
@@ -14,6 +14,7 @@ account     sufficient                                   pam_usertype.so issyste
 account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 account     required                                     pam_permit.so
 
+session     optional                                     pam_env.so                                            {include if "with-session-pam-env"}
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                 {include if "with-ecryptfs"}

--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -30,6 +30,7 @@ password    sufficient                                   pam_unix.so sha512 shad
 password    sufficient                                   pam_sss.so use_authtok
 password    required                                     pam_deny.so
 
+session     optional                                     pam_env.so                                            {include if "with-session-pam-env"}
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}

--- a/profiles/winbind/README
+++ b/profiles/winbind/README
@@ -54,6 +54,10 @@ with-silent-lastlog::
 with-pamaccess::
     Check access.conf during account authorization.
 
+with-session-pam-env::
+    Enable pam_env sessions module.  Useful for setting environment variables
+    for all users via /etc/security/pam_env.conf.
+
 without-nullok::
     Do not add nullok parameter to pam_unix.
 

--- a/profiles/winbind/fingerprint-auth
+++ b/profiles/winbind/fingerprint-auth
@@ -15,6 +15,7 @@ account     required                                     pam_permit.so
 
 password    required                                     pam_deny.so
 
+session     optional                                     pam_env.so                                            {include if "with-session-pam-env"}
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}

--- a/profiles/winbind/password-auth
+++ b/profiles/winbind/password-auth
@@ -22,6 +22,7 @@ password    sufficient                                   pam_unix.so sha512 shad
 password    sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_authtok
 password    required                                     pam_deny.so
 
+session     optional                                     pam_env.so                                            {include if "with-session-pam-env"}
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                  {include if "with-ecryptfs"}

--- a/profiles/winbind/system-auth
+++ b/profiles/winbind/system-auth
@@ -23,6 +23,7 @@ password    sufficient                                   pam_unix.so sha512 shad
 password    sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_authtok
 password    required                                     pam_deny.so
 
+session     optional                                     pam_env.so                                            {include if "with-session-pam-env"}
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}


### PR DESCRIPTION
pam_env is useful for setting environment variables for all pam
sessions.  Among other things, this can be used to set http_proxy
environment variables on a system-wide basis to allow normal networking
functionality on networks that can access the internet only via a proxy.

The existing pam_env in the auth section does not have any effect for
pam sessions that bypass the auth modules, such as cached sudo and
publickey SSH login.

with-session-pam-env enables the pam_env session module in addition to
the always-enabled auth module.  This makes /etc/security/pam_env.conf
settings also take effect for public-key-authenticated SSH and cached
sudo.