### PR TITLE
file_copy: use fchmod() and pass only valid mode bits

### DIFF
--- a/src/lib/util/file.c
+++ b/src/lib/util/file.c
@@ -513,7 +513,7 @@ file_copy(const char *source,
 
     /* Restore original owner and mode.  Errors here are not fatal, since we
      * have the original content already stored and owned by root. */
-    ret = chmod(destpath, statbuf.st_mode);
+    ret = fchmod(fileno(fdest), statbuf.st_mode & ALLPERMS);
     if (ret != 0) {
         ret = errno;
         WARN("Unable to chmod file [%s] [%d]: %s",

--- a/src/lib/util/textfile.c
+++ b/src/lib/util/textfile.c
@@ -169,7 +169,7 @@ textfile_write(const char *filepath,
         goto done;
     }
 
-    ret = chmod(filepath, mode);
+    ret = fchmod(fileno(file), mode);
     if (ret != 0) {
         ret = errno;
         ERROR("Unable to chmod file [%s] [%d]: %s",


### PR DESCRIPTION
Currently in `strace` authselect shows strange system calls like:

chmod("/etc/pam.d/system-auth.NenLC7", 0100644)

The mode parameter actually also contains the type bits, because the
`st_mode` member that was previously obtained from `fstat()` is passed
unmodified.

In this commit a bitwise AND is performed to restrict the parameter to
the permission bits only. Furthermore the `chmod` is changed into an
`fchmod` which is more robust and faster in this context.