### PR TITLE
profiles: add support for resolved

### DIFF
--- a/profiles/minimal/nsswitch.conf
+++ b/profiles/minimal/nsswitch.conf
@@ -2,7 +2,7 @@ aliases:    files                                       {exclude if "with-custom
 automount:  files                                       {exclude if "with-custom-automount"}
 ethers:     files                                       {exclude if "with-custom-ethers"}
 group:      files {if "with-altfiles":altfiles }systemd {exclude if "with-custom-group"}
-hosts:      files dns myhostname                        {exclude if "with-custom-hosts"}
+hosts:      resolve [!UNAVAIL=return] files myhostname dns {exclude if "with-custom-hosts"}
 initgroups: files                                       {exclude if "with-custom-initgroups"}
 netgroup:   files                                       {exclude if "with-custom-netgroup"}
 networks:   files                                       {exclude if "with-custom-networks"}

--- a/profiles/nis/nsswitch.conf
+++ b/profiles/nis/nsswitch.conf
@@ -2,7 +2,7 @@ aliases:    files nis                   {exclude if "with-custom-aliases"}
 automount:  files nis                   {exclude if "with-custom-automount"}
 ethers:     files nis                   {exclude if "with-custom-ethers"}
 group:      files nis systemd           {exclude if "with-custom-group"}
-hosts:      files nis dns myhostname    {exclude if "with-custom-hosts"}
+hosts:      resolve [!UNAVAIL=return] files nis myhostname dns {exclude if "with-custom-hosts"}
 initgroups: files nis                   {exclude if "with-custom-initgroups"}
 netgroup:   files nis                   {exclude if "with-custom-netgroup"}
 networks:   files nis                   {exclude if "with-custom-networks"}


### PR DESCRIPTION
Resolved is enabled by default since Fedora 33 so we need to reflect
this change in our profiles.

It should be OK to enabled it unconditionaly. The module is part of
systemd so it basically can not be uninstalled and it can be safely
disabled through `systemctl disable --now systemd-resolved.service`.

Resolves:
https://github.com/authselect/authselect/issues/221