### PR TITLE
profiles: remove umask argument from pam_oddjob_mkhomedir

### DIFF
--- a/profiles/minimal/password-auth
+++ b/profiles/minimal/password-auth
@@ -17,6 +17,6 @@ session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
 -session    optional                                     pam_systemd.so
-session     optional                                     pam_oddjob_mkhomedir.so umask=0077                    {include if "with-mkhomedir"}
+session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so

--- a/profiles/minimal/system-auth
+++ b/profiles/minimal/system-auth
@@ -17,6 +17,6 @@ session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
 -session    optional                                     pam_systemd.so
-session     optional                                     pam_oddjob_mkhomedir.so umask=0077                    {include if "with-mkhomedir"}
+session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so

--- a/profiles/nis/fingerprint-auth
+++ b/profiles/nis/fingerprint-auth
@@ -15,6 +15,6 @@ session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
 -session     optional                                    pam_systemd.so
-session     optional                                     pam_oddjob_mkhomedir.so umask=0077                    {include if "with-mkhomedir"}
+session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so

--- a/profiles/nis/password-auth
+++ b/profiles/nis/password-auth
@@ -19,6 +19,6 @@ session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                  {include if "with-ecryptfs"}
 -session    optional                                     pam_systemd.so
-session     optional                                     pam_oddjob_mkhomedir.so umask=0077                      {include if "with-mkhomedir"}
+session     optional                                     pam_oddjob_mkhomedir.so                                 {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so

--- a/profiles/nis/system-auth
+++ b/profiles/nis/system-auth
@@ -20,6 +20,6 @@ session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
 -session    optional                                     pam_systemd.so
-session     optional                                     pam_oddjob_mkhomedir.so umask=0077                    {include if "with-mkhomedir"}
+session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so

--- a/profiles/sssd/fingerprint-auth
+++ b/profiles/sssd/fingerprint-auth
@@ -20,7 +20,7 @@ session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
 -session    optional                                     pam_systemd.so
-session     optional                                     pam_oddjob_mkhomedir.so umask=0077                    {include if "with-mkhomedir"}
+session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
 session     optional                                     pam_sss.so

--- a/profiles/sssd/password-auth
+++ b/profiles/sssd/password-auth
@@ -29,7 +29,7 @@ session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
 -session    optional                                     pam_systemd.so
-session     optional                                     pam_oddjob_mkhomedir.so umask=0077                    {include if "with-mkhomedir"}
+session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
 session     optional                                     pam_sss.so

--- a/profiles/sssd/smartcard-auth
+++ b/profiles/sssd/smartcard-auth
@@ -18,7 +18,7 @@ session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                 {include if "with-ecryptfs"}
 -session     optional                                    pam_systemd.so
-session     optional                                     pam_oddjob_mkhomedir.so umask=0077                     {include if "with-mkhomedir"}
+session     optional                                     pam_oddjob_mkhomedir.so                                {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
 session     optional                                     pam_sss.so

--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -34,7 +34,7 @@ session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
 -session    optional                                     pam_systemd.so
-session     optional                                     pam_oddjob_mkhomedir.so umask=0077                    {include if "with-mkhomedir"}
+session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
 session     optional                                     pam_sss.so

--- a/profiles/winbind/fingerprint-auth
+++ b/profiles/winbind/fingerprint-auth
@@ -19,7 +19,7 @@ session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
 -session     optional                                    pam_systemd.so
-session     optional                                     pam_oddjob_mkhomedir.so umask=0077                    {include if "with-mkhomedir"}
+session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
 session     optional                                     pam_winbind.so {if "with-krb5":krb5_auth}

--- a/profiles/winbind/password-auth
+++ b/profiles/winbind/password-auth
@@ -26,7 +26,7 @@ session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                  {include if "with-ecryptfs"}
 -session    optional                                     pam_systemd.so
-session     optional                                     pam_oddjob_mkhomedir.so umask=0077                      {include if "with-mkhomedir"}
+session     optional                                     pam_oddjob_mkhomedir.so                                 {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
 session     optional                                     pam_winbind.so {if "with-krb5":krb5_auth}

--- a/profiles/winbind/system-auth
+++ b/profiles/winbind/system-auth
@@ -27,7 +27,7 @@ session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
 -session    optional                                     pam_systemd.so
-session     optional                                     pam_oddjob_mkhomedir.so umask=0077                    {include if "with-mkhomedir"}
+session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
 session     optional                                     pam_winbind.so {if "with-krb5":krb5_auth}


### PR DESCRIPTION
The module does not support this argument. It is a left over from
a time when pam_mkhomedir was used.

Resolves:
https://github.com/authselect/authselect/issues/223