### PR TITLE
spec: Add nss-altfiles on Silverblue

### DIFF
--- a/rpm/authselect.spec.in
+++ b/rpm/authselect.spec.in
@@ -245,6 +245,14 @@ if [ -f %{validfile} ]; then
     %__rm -f %{validfile}
 fi
 
+# Add nss-altfiles if we are on Silverblue
+if %__grep -i silverblue /etc/os-release &> /dev/null; then
+    for PROFILE in `ls %{_datadir}/authselect/default`; do
+        %{_bindir}/authselect create-profile $PROFILE --vendor --base-on $PROFILE --symlink-pam --symlink-dconf --symlink=REQUIREMENTS --symlink=README &> /dev/null
+        %__sed -ie "s/^\(passwd\|group\):\(.*\)systemd\(.*\)/\1:\2systemd altfiles\3/g" %{_datadir}/authselect/vendor/$PROFILE/nsswitch.conf &> /dev/null
+    done
+fi
+
 # Apply any changes to profiles (validates configuration first internally)
 %{_bindir}/authselect apply-changes &> /dev/null
 


### PR DESCRIPTION
This module is required on Silverblue to resolve several system users.
Systems gets broken if the module is not present in nsswitch.conf.

Resolves:
https://github.com/authselect/authselect/issues/226