### PR TITLE
CI: Build fails under Fedora 33 container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 # Travis CI script
+language: shell
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,6 @@ arch: amd64
 os: linux
 dist: focal
 
-sudo: false
-
 services:
 - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 # Travis CI script
 language: shell
 
+arch: amd64
+os: linux
+dist: focal
+
 sudo: false
 
 services:


### PR DESCRIPTION
Last fedora container doesn't run well under xenial (default).
We have to move with our container to newer host (focal).
