### PR TITLE
fingerprint: Retain error code returned by pam_fprintd.so

### DIFF
--- a/profiles/nis/fingerprint-auth
+++ b/profiles/nis/fingerprint-auth
@@ -1,7 +1,7 @@
 {continue if "with-fingerprint"}
 auth        required                                     pam_env.so
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
-auth        sufficient                                   pam_fprintd.so
+auth        required                                     pam_fprintd.so
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so
 

--- a/profiles/sssd/fingerprint-auth
+++ b/profiles/sssd/fingerprint-auth
@@ -2,7 +2,7 @@
 auth        required                                     pam_env.so
 auth        required                                     pam_deny.so # Smartcard authentication is required     {include if "with-smartcard-required"}
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
-auth        sufficient                                   pam_fprintd.so
+auth        required                                     pam_fprintd.so
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so
 

--- a/profiles/winbind/fingerprint-auth
+++ b/profiles/winbind/fingerprint-auth
@@ -1,7 +1,7 @@
 {continue if "with-fingerprint"}
 auth        required                                     pam_env.so
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
-auth        sufficient                                   pam_fprintd.so
+auth        required                                     pam_fprintd.so
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so
 


### PR DESCRIPTION
pam_fprintd.so will return PAM_AUTHINFO_UNAVAIL in some situations. It
is important that the fingerprint-auth stack returns this error code, so
that users (i.e. GDM) can tell the difference between an authentication
failure vs. an immediate return because no fingers are enrolled.

Fix this by changing sufficient to [success=ok default=bad] in order to
ensure that the pam_fprintd.so error code is returned.