### PR TITLE
fingerprint: Fix fingerprint authentication

### DIFF
--- a/profiles/nis/fingerprint-auth
+++ b/profiles/nis/fingerprint-auth
@@ -1,7 +1,7 @@
 {continue if "with-fingerprint"}
 auth        required                                     pam_env.so
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
-auth        required                                     pam_fprintd.so
+auth        [success=done default=bad]                   pam_fprintd.so
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so
 

--- a/profiles/sssd/fingerprint-auth
+++ b/profiles/sssd/fingerprint-auth
@@ -2,7 +2,7 @@
 auth        required                                     pam_env.so
 auth        required                                     pam_deny.so # Smartcard authentication is required     {include if "with-smartcard-required"}
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
-auth        required                                     pam_fprintd.so
+auth        [success=done default=bad]                   pam_fprintd.so
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so
 

--- a/profiles/winbind/fingerprint-auth
+++ b/profiles/winbind/fingerprint-auth
@@ -1,7 +1,7 @@
 {continue if "with-fingerprint"}
 auth        required                                     pam_env.so
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
-auth        required                                     pam_fprintd.so
+auth        [success=done default=bad]                   pam_fprintd.so
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so
 


### PR DESCRIPTION
Commit b1bd29712fe8 ("fingerprint: Retain error code returned by
pam_fprintd.so") changed the pam_fprintd.so module to be included using
"required". This changes sets "default=bad", however changed the
"success" configuration from "success=done" to "success=ok" resulting in
the later pam_deny.so to prevent authentication.

The fix is simple, explicitly set "[success=done default=bad]" so that
we get the best of both worlds. Error reporting and working
authentication.