### PR TITLE
profiles: add pam_debug to empty fingerprint and smartcard stack

### DIFF
--- a/profiles/Makefile.am
+++ b/profiles/Makefile.am
@@ -8,7 +8,9 @@ dist_profile_minimal_DATA = \
     $(top_srcdir)/profiles/minimal/postlogin \
     $(top_srcdir)/profiles/minimal/README \
     $(top_srcdir)/profiles/minimal/REQUIREMENTS \
+    $(top_srcdir)/profiles/minimal/smartcard-auth \
     $(top_srcdir)/profiles/minimal/system-auth \
+    $(top_srcdir)/profiles/minimal/fingerprint-auth \
     $(top_srcdir)/profiles/minimal/dconf-db \
     $(top_srcdir)/profiles/minimal/dconf-locks \
     $(NULL)
@@ -20,6 +22,7 @@ dist_profile_nis_DATA = \
     $(top_srcdir)/profiles/nis/postlogin \
     $(top_srcdir)/profiles/nis/README \
     $(top_srcdir)/profiles/nis/REQUIREMENTS \
+    $(top_srcdir)/profiles/nis/smartcard-auth \
     $(top_srcdir)/profiles/nis/system-auth \
     $(top_srcdir)/profiles/nis/fingerprint-auth \
     $(top_srcdir)/profiles/nis/dconf-db \
@@ -47,6 +50,7 @@ dist_profile_winbind_DATA = \
     $(top_srcdir)/profiles/winbind/postlogin \
     $(top_srcdir)/profiles/winbind/README \
     $(top_srcdir)/profiles/winbind/REQUIREMENTS \
+    $(top_srcdir)/profiles/winbind/smartcard-auth \
     $(top_srcdir)/profiles/winbind/system-auth \
     $(top_srcdir)/profiles/winbind/fingerprint-auth \
     $(top_srcdir)/profiles/winbind/dconf-db \

--- a/profiles/minimal/fingerprint-auth
+++ b/profiles/minimal/fingerprint-auth
@@ -1,0 +1,1 @@
+auth required pam_debug.so auth=authinfo_unavail

--- a/profiles/minimal/smartcard-auth
+++ b/profiles/minimal/smartcard-auth
@@ -1,0 +1,1 @@
+auth required pam_debug.so auth=authinfo_unavail

--- a/profiles/nis/fingerprint-auth
+++ b/profiles/nis/fingerprint-auth
@@ -1,3 +1,4 @@
+auth required pam_debug.so auth=authinfo_unavail {exclude if "with-fingerprint"}
 {continue if "with-fingerprint"}
 auth        required                                     pam_env.so
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}

--- a/profiles/nis/smartcard-auth
+++ b/profiles/nis/smartcard-auth
@@ -1,0 +1,1 @@
+auth required pam_debug.so auth=authinfo_unavail

--- a/profiles/sssd/fingerprint-auth
+++ b/profiles/sssd/fingerprint-auth
@@ -1,3 +1,4 @@
+auth required pam_debug.so auth=authinfo_unavail {exclude if "with-fingerprint"}
 {continue if "with-fingerprint"}
 auth        required                                     pam_env.so
 auth        required                                     pam_deny.so # Smartcard authentication is required     {include if "with-smartcard-required"}

--- a/profiles/sssd/smartcard-auth
+++ b/profiles/sssd/smartcard-auth
@@ -1,4 +1,5 @@
 {imply "with-smartcard" if "with-smartcard-required"}
+auth required pam_debug.so auth=authinfo_unavail {exclude if "with-smartcard"}
 {continue if "with-smartcard"}
 auth        required                                     pam_env.so
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}

--- a/profiles/winbind/fingerprint-auth
+++ b/profiles/winbind/fingerprint-auth
@@ -1,3 +1,4 @@
+auth required pam_debug.so auth=authinfo_unavail {exclude if "with-fingerprint"}
 {continue if "with-fingerprint"}
 auth        required                                     pam_env.so
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}

--- a/profiles/winbind/smartcard-auth
+++ b/profiles/winbind/smartcard-auth
@@ -1,0 +1,1 @@
+auth required pam_debug.so auth=authinfo_unavail

--- a/rpm/authselect.spec.in
+++ b/rpm/authselect.spec.in
@@ -158,11 +158,13 @@ find $RPM_BUILD_ROOT -name "*.a" -exec %__rm -f {} \;
 %dir %{_datadir}/authselect/default/nis/
 %dir %{_datadir}/authselect/default/sssd/
 %dir %{_datadir}/authselect/default/winbind/
+%{_datadir}/authselect/default/minimal/fingerprint-auth
 %{_datadir}/authselect/default/minimal/nsswitch.conf
 %{_datadir}/authselect/default/minimal/password-auth
 %{_datadir}/authselect/default/minimal/postlogin
 %{_datadir}/authselect/default/minimal/README
 %{_datadir}/authselect/default/minimal/REQUIREMENTS
+%{_datadir}/authselect/default/minimal/smartcard-auth
 %{_datadir}/authselect/default/minimal/system-auth
 %{_datadir}/authselect/default/nis/dconf-db
 %{_datadir}/authselect/default/nis/dconf-locks
@@ -172,6 +174,7 @@ find $RPM_BUILD_ROOT -name "*.a" -exec %__rm -f {} \;
 %{_datadir}/authselect/default/nis/postlogin
 %{_datadir}/authselect/default/nis/README
 %{_datadir}/authselect/default/nis/REQUIREMENTS
+%{_datadir}/authselect/default/nis/smartcard-auth
 %{_datadir}/authselect/default/nis/system-auth
 %{_datadir}/authselect/default/sssd/dconf-db
 %{_datadir}/authselect/default/sssd/dconf-locks
@@ -191,6 +194,7 @@ find $RPM_BUILD_ROOT -name "*.a" -exec %__rm -f {} \;
 %{_datadir}/authselect/default/winbind/postlogin
 %{_datadir}/authselect/default/winbind/README
 %{_datadir}/authselect/default/winbind/REQUIREMENTS
+%{_datadir}/authselect/default/winbind/smartcard-auth
 %{_datadir}/authselect/default/winbind/system-auth
 %{_libdir}/libauthselect.so.*
 %{_mandir}/man5/authselect-profiles.5*

--- a/rpm/authselect.spec.in
+++ b/rpm/authselect.spec.in
@@ -158,6 +158,8 @@ find $RPM_BUILD_ROOT -name "*.a" -exec %__rm -f {} \;
 %dir %{_datadir}/authselect/default/nis/
 %dir %{_datadir}/authselect/default/sssd/
 %dir %{_datadir}/authselect/default/winbind/
+%{_datadir}/authselect/default/minimal/dconf-db
+%{_datadir}/authselect/default/minimal/dconf-locks
 %{_datadir}/authselect/default/minimal/fingerprint-auth
 %{_datadir}/authselect/default/minimal/nsswitch.conf
 %{_datadir}/authselect/default/minimal/password-auth


### PR DESCRIPTION
This way if someone tries to use the stack it will return AUTHINFO_UNAVAIL.

   Resolves: https://github.com/authselect/authselect/issues/238