### PR TITLE
profiles: use yescrypt hashing method for shadow passwords

### DIFF
--- a/po/authselect.pot
+++ b/po/authselect.pot
@@ -1535,7 +1535,7 @@ msgid "<name>"
 msgstr ""
 
 #: src/compat/authcompat_Options.py:148
-msgid "<descrypt|bigcrypt|md5|sha256|sha512>"
+msgid "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
 msgstr ""
 
 #: src/compat/authcompat_Options.py:149

--- a/po/ca.po
+++ b/po/ca.po
@@ -1574,7 +1574,7 @@ msgid "<name>"
 msgstr ""
 
 #: src/compat/authcompat_Options.py:148
-msgid "<descrypt|bigcrypt|md5|sha256|sha512>"
+msgid "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
 msgstr ""
 
 #: src/compat/authcompat_Options.py:149

--- a/po/cs.po
+++ b/po/cs.po
@@ -1620,8 +1620,8 @@ msgid "<name>"
 msgstr "<name>"
 
 #: src/compat/authcompat_Options.py:148
-msgid "<descrypt|bigcrypt|md5|sha256|sha512>"
-msgstr "<descrypt|bigcrypt|md5|sha256|sha512>"
+msgid "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
+msgstr "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
 
 # auto translated by TM merge from project: authconfig, version: master, DocId: po/authconfig
 #: src/compat/authcompat_Options.py:149

--- a/po/de.po
+++ b/po/de.po
@@ -1610,8 +1610,8 @@ msgid "<name>"
 msgstr "<name>"
 
 #: src/compat/authcompat_Options.py:148
-msgid "<descrypt|bigcrypt|md5|sha256|sha512>"
-msgstr "<descrypt|bigcrypt|md5|sha256|sha512>"
+msgid "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
+msgstr "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
 
 #: src/compat/authcompat_Options.py:149
 msgid "<URL>"

--- a/po/es.po
+++ b/po/es.po
@@ -1601,8 +1601,8 @@ msgid "<name>"
 msgstr "<nombre>"
 
 #: src/compat/authcompat_Options.py:148
-msgid "<descrypt|bigcrypt|md5|sha256|sha512>"
-msgstr "<descrypt|bigcrypt|md5|sha256|sha512>"
+msgid "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
+msgstr "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
 
 #: src/compat/authcompat_Options.py:149
 msgid "<URL>"

--- a/po/fa.po
+++ b/po/fa.po
@@ -1533,7 +1533,7 @@ msgid "<name>"
 msgstr ""
 
 #: src/compat/authcompat_Options.py:148
-msgid "<descrypt|bigcrypt|md5|sha256|sha512>"
+msgid "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
 msgstr ""
 
 #: src/compat/authcompat_Options.py:149

--- a/po/fr.po
+++ b/po/fr.po
@@ -1605,8 +1605,8 @@ msgid "<name>"
 msgstr "<name>"
 
 #: src/compat/authcompat_Options.py:148
-msgid "<descrypt|bigcrypt|md5|sha256|sha512>"
-msgstr "<descrypt|bigcrypt|md5|sha256|sha512>"
+msgid "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
+msgstr "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
 
 #: src/compat/authcompat_Options.py:149
 msgid "<URL>"

--- a/po/hu.po
+++ b/po/hu.po
@@ -1598,8 +1598,8 @@ msgid "<name>"
 msgstr "<név>"
 
 #: src/compat/authcompat_Options.py:148
-msgid "<descrypt|bigcrypt|md5|sha256|sha512>"
-msgstr "<descrypt|bigcrypt|md5|sha256|sha512>"
+msgid "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
+msgstr "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
 
 #: src/compat/authcompat_Options.py:149
 msgid "<URL>"

--- a/po/it.po
+++ b/po/it.po
@@ -1589,8 +1589,8 @@ msgid "<name>"
 msgstr "<name>"
 
 #: src/compat/authcompat_Options.py:148
-msgid "<descrypt|bigcrypt|md5|sha256|sha512>"
-msgstr "<descrypt|bigcrypt|md5|sha256|sha512>"
+msgid "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
+msgstr "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
 
 #: src/compat/authcompat_Options.py:149
 msgid "<URL>"

--- a/po/ja.po
+++ b/po/ja.po
@@ -1597,8 +1597,8 @@ msgid "<name>"
 msgstr "<name>"
 
 #: src/compat/authcompat_Options.py:148
-msgid "<descrypt|bigcrypt|md5|sha256|sha512>"
-msgstr "<descrypt|bigcrypt|md5|sha256|sha512>"
+msgid "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
+msgstr "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
 
 # auto translated by TM merge from translation memory: authconfig, unique id: authconfig:6.2.8:authconfig:0bbce02e304562c295a1d57d66c296d3
 #: src/compat/authcompat_Options.py:149

--- a/po/ko.po
+++ b/po/ko.po
@@ -1562,8 +1562,8 @@ msgid "<name>"
 msgstr "<name>"
 
 #: src/compat/authcompat_Options.py:148
-msgid "<descrypt|bigcrypt|md5|sha256|sha512>"
-msgstr "<descrypt|bigcrypt|md5|sha256|sha512>"
+msgid "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
+msgstr "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
 
 #: src/compat/authcompat_Options.py:149
 msgid "<URL>"

--- a/po/nl.po
+++ b/po/nl.po
@@ -1598,8 +1598,8 @@ msgid "<name>"
 msgstr "<name>"
 
 #: src/compat/authcompat_Options.py:148
-msgid "<descrypt|bigcrypt|md5|sha256|sha512>"
-msgstr "<descrypt|bigcrypt|md5|sha256|sha512>"
+msgid "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
+msgstr "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
 
 #: src/compat/authcompat_Options.py:149
 msgid "<URL>"

--- a/po/pl.po
+++ b/po/pl.po
@@ -1609,8 +1609,8 @@ msgid "<name>"
 msgstr "<nazwa>"
 
 #: src/compat/authcompat_Options.py:148
-msgid "<descrypt|bigcrypt|md5|sha256|sha512>"
-msgstr "<descrypt|bigcrypt|md5|sha256|sha512>"
+msgid "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
+msgstr "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
 
 #: src/compat/authcompat_Options.py:149
 msgid "<URL>"

--- a/po/pt.po
+++ b/po/pt.po
@@ -1540,7 +1540,7 @@ msgid "<name>"
 msgstr ""
 
 #: src/compat/authcompat_Options.py:148
-msgid "<descrypt|bigcrypt|md5|sha256|sha512>"
+msgid "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
 msgstr ""
 
 #: src/compat/authcompat_Options.py:149

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -1597,8 +1597,8 @@ msgid "<name>"
 msgstr "<name>"
 
 #: src/compat/authcompat_Options.py:148
-msgid "<descrypt|bigcrypt|md5|sha256|sha512>"
-msgstr "<descrypt|bigcrypt|md5|sha256|sha512>"
+msgid "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
+msgstr "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
 
 #: src/compat/authcompat_Options.py:149
 msgid "<URL>"

--- a/po/ru.po
+++ b/po/ru.po
@@ -1589,8 +1589,8 @@ msgid "<name>"
 msgstr "<name>"
 
 #: src/compat/authcompat_Options.py:148
-msgid "<descrypt|bigcrypt|md5|sha256|sha512>"
-msgstr "<descrypt|bigcrypt|md5|sha256|sha512>"
+msgid "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
+msgstr "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
 
 #: src/compat/authcompat_Options.py:149
 msgid "<URL>"

--- a/po/si.po
+++ b/po/si.po
@@ -1533,7 +1533,7 @@ msgid "<name>"
 msgstr ""
 
 #: src/compat/authcompat_Options.py:148
-msgid "<descrypt|bigcrypt|md5|sha256|sha512>"
+msgid "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
 msgstr ""
 
 #: src/compat/authcompat_Options.py:149

--- a/po/sv.po
+++ b/po/sv.po
@@ -1579,8 +1579,8 @@ msgid "<name>"
 msgstr "<namn>"
 
 #: src/compat/authcompat_Options.py:148
-msgid "<descrypt|bigcrypt|md5|sha256|sha512>"
-msgstr "<descrypt|bigcrypt|md5|sha256|sha512>"
+msgid "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
+msgstr "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
 
 #: src/compat/authcompat_Options.py:149
 msgid "<URL>"

--- a/po/tr.po
+++ b/po/tr.po
@@ -1588,8 +1588,8 @@ msgid "<name>"
 msgstr "<isim>"
 
 #: src/compat/authcompat_Options.py:148
-msgid "<descrypt|bigcrypt|md5|sha256|sha512>"
-msgstr "<descrypt|bigcrypt|md5|sha256|sha512>"
+msgid "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
+msgstr "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
 
 #: src/compat/authcompat_Options.py:149
 msgid "<URL>"

--- a/po/uk.po
+++ b/po/uk.po
@@ -1591,8 +1591,8 @@ msgid "<name>"
 msgstr "<назва>"
 
 #: src/compat/authcompat_Options.py:148
-msgid "<descrypt|bigcrypt|md5|sha256|sha512>"
-msgstr "<descrypt|bigcrypt|md5|sha256|sha512>"
+msgid "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
+msgstr "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
 
 #: src/compat/authcompat_Options.py:149
 msgid "<URL>"

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -1559,8 +1559,8 @@ msgid "<name>"
 msgstr "<name>"
 
 #: src/compat/authcompat_Options.py:148
-msgid "<descrypt|bigcrypt|md5|sha256|sha512>"
-msgstr "<descrypt|bigcrypt|md5|sha256|sha512>"
+msgid "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
+msgstr "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
 
 #: src/compat/authcompat_Options.py:149
 msgid "<URL>"

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -1568,8 +1568,8 @@ msgid "<name>"
 msgstr "<name>"
 
 #: src/compat/authcompat_Options.py:148
-msgid "<descrypt|bigcrypt|md5|sha256|sha512>"
-msgstr "<descrypt|bigcrypt|md5|sha256|sha512>"
+msgid "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
+msgstr "<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>"
 
 #: src/compat/authcompat_Options.py:149
 msgid "<URL>"

--- a/profiles/minimal/password-auth
+++ b/profiles/minimal/password-auth
@@ -10,7 +10,7 @@ account     required                                     pam_faillock.so        
 account     required                                     pam_unix.so
 
 password    requisite                                    pam_pwquality.so
-password    sufficient                                   pam_unix.so sha512 shadow {if not "without-nullok":nullok} use_authtok
+password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
 password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so revoke

--- a/profiles/minimal/system-auth
+++ b/profiles/minimal/system-auth
@@ -10,7 +10,7 @@ account     required                                     pam_faillock.so        
 account     required                                     pam_unix.so
 
 password    requisite                                    pam_pwquality.so
-password    sufficient                                   pam_unix.so sha512 shadow {if not "without-nullok":nullok} use_authtok
+password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
 password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so revoke

--- a/profiles/nis/password-auth
+++ b/profiles/nis/password-auth
@@ -12,7 +12,7 @@ account     required                                     pam_faillock.so        
 account     required                                     pam_unix.so broken_shadow
 
 password    requisite                                    pam_pwquality.so {if not "with-nispwquality":local_users_only}
-password    sufficient                                   pam_unix.so sha512 shadow {if not "without-nullok":nullok} use_authtok nis
+password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok nis
 password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so revoke

--- a/profiles/nis/system-auth
+++ b/profiles/nis/system-auth
@@ -13,7 +13,7 @@ account     required                                     pam_faillock.so        
 account     required                                     pam_unix.so broken_shadow
 
 password    requisite                                    pam_pwquality.so {if not "with-nispwquality":local_users_only}
-password    sufficient                                   pam_unix.so sha512 shadow {if not "without-nullok":nullok} use_authtok nis
+password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok nis
 password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so revoke

--- a/profiles/sssd/password-auth
+++ b/profiles/sssd/password-auth
@@ -21,7 +21,7 @@ account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 account     required                                     pam_permit.so
 
 password    requisite                                    pam_pwquality.so local_users_only
-password    sufficient                                   pam_unix.so sha512 shadow {if not "without-nullok":nullok} use_authtok
+password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
 password    sufficient                                   pam_sss.so use_authtok
 password    required                                     pam_deny.so
 

--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -26,7 +26,7 @@ account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 account     required                                     pam_permit.so
 
 password    requisite                                    pam_pwquality.so local_users_only
-password    sufficient                                   pam_unix.so sha512 shadow {if not "without-nullok":nullok} use_authtok
+password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
 password    sufficient                                   pam_sss.so use_authtok
 password    required                                     pam_deny.so
 

--- a/profiles/winbind/password-auth
+++ b/profiles/winbind/password-auth
@@ -18,7 +18,7 @@ account     [default=bad success=ok user_unknown=ignore] pam_winbind.so {if "wit
 account     required                                     pam_permit.so
 
 password    requisite                                    pam_pwquality.so local_users_only
-password    sufficient                                   pam_unix.so sha512 shadow {if not "without-nullok":nullok} use_authtok
+password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
 password    sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_authtok
 password    required                                     pam_deny.so
 

--- a/profiles/winbind/system-auth
+++ b/profiles/winbind/system-auth
@@ -19,7 +19,7 @@ account     [default=bad success=ok user_unknown=ignore] pam_winbind.so {if "wit
 account     required                                     pam_permit.so
 
 password    requisite                                    pam_pwquality.so local_users_only
-password    sufficient                                   pam_unix.so sha512 shadow {if not "without-nullok":nullok} use_authtok
+password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
 password    sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_authtok
 password    required                                     pam_deny.so
 

--- a/src/compat/authcompat_Options.py
+++ b/src/compat/authcompat_Options.py
@@ -145,7 +145,7 @@ class Options:
         Option.UnsupportedSwitch ("useshadow"),
         Option.UnsupportedFeature("md5"),
         Option.UnsupportedSwitch ("usemd5"),
-        Option.UnsupportedValued ("passalgo", _("<descrypt|bigcrypt|md5|sha256|sha512>")),
+        Option.UnsupportedValued ("passalgo", _("<descrypt|bigcrypt|md5|sha256|sha512|yescrypt>")),
         Option.UnsupportedValued ("ldaploadcacert", _("<URL>")),
         Option.UnsupportedValued ("smartcardmodule", _("<module>")),
         Option.UnsupportedValued ("smbsecurity", _("<user|server|domain|ads>")),

--- a/src/man/authselect-migration.7.adoc
+++ b/src/man/authselect-migration.7.adoc
@@ -1,6 +1,6 @@
 authselect-migration(7)
 =======================
-:revdate: 2018-03-18
+:revdate: 2021-06-05
 
 NAME
 ----
@@ -91,9 +91,9 @@ configuration file for required services.
 
 NOTE: Authconfig options `--enableshadow` and `--passalgo=sha512` were often
 used to make sure that passwords are stored in `/etc/shadow` using `sha512`
-algorithm. *This is default in authselect profiles* and it cannot be changed
-through an option (only by creating a custom profile). You can just
-omit these options.
+algorithm. *The authselect profiles now use the yescrypt hashing method* and
+it cannot be changed through an option (only by creating a custom profile).
+You can just omit these options.
 
 .Examples
 ----


### PR DESCRIPTION
The yescrypt hashing method is considered to be much stronger than sha512crypt and fully supported by libxcrypt.  It is based
on NIST-approved primitives and on par with argon2 in strength.

Fresh installed systems, as well as newly computed hashes for the UNIX shadow file should prefer this method.