### PR TITLE
sssd: default to files first for users and groups

### DIFF
--- a/profiles/sssd/README
+++ b/profiles/sssd/README
@@ -79,6 +79,11 @@ with-sudo::
 with-pamaccess::
     Check access.conf during account authorization.
 
+with-files-domain::
+    If set, SSSD will be contacted before "files" when resolving users and
+    groups. The order in nsswitch.conf will be set to "sss files" instead of
+    "files sss" for passwd and group maps.
+
 with-files-access-provider::
     If set, account management for local users is handled also by pam_sss. This
     is needed if there is an explicitly configured domain with id_provider=files

--- a/profiles/sssd/REQUIREMENTS
+++ b/profiles/sssd/REQUIREMENTS
@@ -14,3 +14,7 @@ Make sure that SSSD service is configured and enabled. See SSSD documentation fo
 - with-mkhomedir is selected, make sure pam_oddjob_mkhomedir module                       {include if "with-mkhomedir"}
   is present and oddjobd service is enabled and active                                    {include if "with-mkhomedir"}
   - systemctl enable --now oddjobd.service                                                {include if "with-mkhomedir"}
+                                                                                          {include if "with-files-domain"}
+- with-files-domain is selected, make sure the files provider is enabled in SSSD          {include if "with-files-domain"}
+  - set enable_files_domain=true in [sssd] section of /etc/sssd/sssd.conf                 {include if "with-files-domain"}
+  - or create a custom domain with id_provider=files                                      {include if "with-files-domain"}

--- a/profiles/sssd/nsswitch.conf
+++ b/profiles/sssd/nsswitch.conf
@@ -1,5 +1,5 @@
-passwd:     sss files systemd   {exclude if "with-custom-passwd"}
-group:      sss files systemd   {exclude if "with-custom-group"}
+passwd:     {if "with-files-domain":sss files|files sss} systemd   {exclude if "with-custom-passwd"}
+group:      {if "with-files-domain":sss files|files sss} systemd   {exclude if "with-custom-group"}
 netgroup:   sss files           {exclude if "with-custom-netgroup"}
 automount:  sss files           {exclude if "with-custom-automount"}
 services:   sss files           {exclude if "with-custom-services"}


### PR DESCRIPTION
The passwd and group databases will now default to files first.
The order "sss files" can be enabled with "with-files-provider"
feature.

This relates to F35 change:
https://fedoraproject.org/wiki/Changes/FlexibleLocalUserCache

Resolves:
https://github.com/authselect/authselect/issues/254