### PR TITLE
lib: avoid freeing uninitialized variable in authselect_apply_changes()

### DIFF
--- a/src/lib/authselect.c
+++ b/src/lib/authselect.c
@@ -163,7 +163,7 @@ authselect_uninstall(void)
 _PUBLIC_ int
 authselect_apply_changes(void)
 {
-    struct authselect_profile *profile;
+    struct authselect_profile *profile = NULL;
     char **supported = NULL;
     char *profile_id;
     char **features;


### PR DESCRIPTION
If authselect_profile() fails, we goto done and try to free uninitialized
variable.

Resolves:
https://github.com/authselect/authselect/issues/265