### PR TITLE
spec: remove translations.tgz from spec file for rhel

### DIFF
--- a/rpm/authselect.spec.in
+++ b/rpm/authselect.spec.in
@@ -9,9 +9,6 @@ URL:            https://github.com/authselect/authselect
 
 License:        GPLv3+
 Source0:        %{url}/archive/%{version}/%{name}-%{version}.tar.gz
-%if 0%{?rhel}
-Source1:        translations.tar.gz
-%endif
 
 %global makedir %{_builddir}/%{name}-%{version}
 
@@ -73,14 +70,6 @@ you develop a front-end for the authselect library.
 for p in %patches ; do
     %__patch -p1 -i $p
 done
-
-# Install RHEL translations
-# It is not possible to use wildcards here so we need to use 'find'
-%if 0%{?rhel}
-find "%{makedir}/po" "%{makedir}/src/man/po" -name "*.po" -delete
-%__rm "%{makedir}/po/LINGUAS"
-%setup -T -D -a 1
-%endif
 
 %build
 autoreconf -if


### PR DESCRIPTION
This is not used anymore.