### PR TITLE
authselect.spec: Add nss-altfiles for all ostree systems

### DIFF
--- a/rpm/authselect.spec.in
+++ b/rpm/authselect.spec.in
@@ -236,8 +236,9 @@ if [ -f %{validfile} ]; then
     %__rm -f %{validfile}
 fi
 
-# Add nss-altfiles if we are on Kinoite or Silverblue
-if %__grep -Ei "kinoite|silverblue" /etc/os-release &> /dev/null; then
+# Keep nss-altfiles for all rpm-ostree based systems.
+# See https://github.com/authselect/authselect/issues/48
+if %__grep "OSTREE_VERSION=" /etc/os-release &> /dev/null; then
     for PROFILE in `ls %{_datadir}/authselect/default`; do
         %{_bindir}/authselect create-profile $PROFILE --vendor --base-on $PROFILE --symlink-pam --symlink-dconf --symlink=REQUIREMENTS --symlink=README &> /dev/null
         %__sed -ie "s/^\(passwd\|group\):\(.*\)systemd\(.*\)/\1:\2systemd altfiles\3/g" %{_datadir}/authselect/vendor/$PROFILE/nsswitch.conf &> /dev/null


### PR DESCRIPTION
All rpm-ostree based systems currently rely on nss-altfiles for user and
group lookups. Thus generalize the logic to match for 'OSTREE_VERSION'
instead of specific variants during installation.

See: https://github.com/authselect/authselect/issues/48
Fixes: https://github.com/authselect/authselect/commit/c2b1b7a72b8b2efb3c244feca65abd692b0ed599
Fixes: https://github.com/authselect/authselect/commit/9e14ff3cd1cb8a84561d1b8adeaf00c42c4ce5c4