### PR TITLE
sssd README: Fix manpage section for sssd.conf

### DIFF
--- a/profiles/sssd/README
+++ b/profiles/sssd/README
@@ -134,4 +134,4 @@ EXAMPLES
 
 SEE ALSO
 --------
-* man sssd.conf(8)
+* man sssd.conf(5)


### PR DESCRIPTION
As a configuration file, the manpage for `sssd.conf` can be found in section 5, not 8.