### PR TITLE
main: Drop an unnecessary `NULL` check before `free()`

### DIFF
--- a/src/cli/main.c
+++ b/src/cli/main.c
@@ -231,9 +231,7 @@ done:
     free(requirements);
     authselect_array_free(maps);
     authselect_profile_free(profile);
-    if (features != NULL) {
-        free(features);
-    }
+    free(features);
 
     return ret;
 }


### PR DESCRIPTION
From `man free()`:

```
The free() function frees the memory space pointed to by ptr ...  If ptr is NULL, no operation is performed.
```

Obviously there are *tons* of these in the codebase; just doing
this one as a preliminary PR; if accepted I may do some more, or
others can.  Or we could try a coccinelle semantic patch.