### PR TITLE
Two ostree/rpm-ostree compatibility patches

### DIFF
--- a/src/lib/files/config.c
+++ b/src/lib/files/config.c
@@ -142,15 +142,26 @@ authselect_config_locations_writable()
 {
     struct authselect_symlink files[] = {
         {PATH_CONFIG_FILE, NULL, false},
-        {PATH_COPY_SYSTEM, NULL, false},
-        SYMLINK_FILES
+        SYMLINK_FILES,
+        {PATH_COPY_SYSTEM, NULL, false}
     };
     bool result = true;
     char *dirpath;
     errno_t ret;
     int i;
+    bool maintain_shadow = true;
 
     INFO("Checking if all required directories are writable.");
+
+    ret = should_maintain_shadow_copy(&maintain_shadow);
+    if (ret != EOK) {
+        ERROR("Failed to query for shadow copy state");
+        return false;
+    }
+    if (!maintain_shadow) {
+        /* Neuter the PATH_COPY_SYSTEM bits */
+        files[2].name = NULL;
+    }
 
     for (i = 0; files[i].name != NULL; i++) {
         dirpath = file_get_parent_directory(files[i].name);

--- a/src/lib/paths.h
+++ b/src/lib/paths.h
@@ -22,6 +22,7 @@
 #define _AUTHSELECT_PATHS_H_
 
 #include <stdbool.h>
+#include "common/errno_t.h"
 
 /* Authselect configuration file. */
 #define FILE_CONFIG      "authselect.conf"
@@ -163,5 +164,7 @@ struct authselect_symlink {
 #define FILES_DCONF     FILE_DCONF_DB, FILE_DCONF_LOCK
 
 #define FILES_ALL       FILES_META, FILES_NSSWITCH, FILES_PAM, FILES_DCONF
+
+errno_t should_maintain_shadow_copy(bool* should_shadow);
 
 #endif /* _AUTHSELECT_PATHS_H_ */


### PR DESCRIPTION
Default to `--no-backup` if system is not initialized

If there's no configuration, then there's nothing to back up.
This means things "just work" with rpm-ostree, which makes
`/var` a read-only bind mount while scripts execute (to help
preserve user data).

In fact, the whole "backup configuration" thing is ideally long
term unnecessary on ostree systems, because ostree has the
capability to make *all* configuration changes transactional.

But for now this is really about making the existing code in
the `%posttrans` work.  This idea isn't ostree specific; I don't
see a reason to try to back up nonexistent configuration during an Anaconda
run for example either.

---

Don't try to write to `/var/lib/authselect` if it's read-only

I haven't fully grasped what authselect is trying to do with
the files in `/var/lib/authselect`.  This patch changes things
so that we skip trying to write to them if the path is read-only,
as will occur in `rpm-ostree compose tree` at build time.

I *think* these are backup copies of the files authselect uses to
detect "drift" from the files it wrote at the time of invocation.

If so, I think it's better to store them in `/etc/authselect/_pristine`
or something.  Or, add checksums as xattrs on the files.

In any case, this is now sufficient to get me a booting FCOS
system in concert with https://github.com/coreos/rpm-ostree/pull/3308

---

