### PR TITLE
Added feature with-pam-gnome-keyring.

### DIFF
--- a/profiles/nis/README
+++ b/profiles/nis/README
@@ -27,6 +27,9 @@ with-ecryptfs::
 with-fingerprint::
     Enable authentication with fingerprint reader through *pam_fprintd*.
 
+with-pam-gnome-keyring::
+    Enable pam-gnome-keyring support.
+
 with-pam-u2f::
     Enable authentication via u2f dongle through *pam_u2f*.
 

--- a/profiles/nis/REQUIREMENTS
+++ b/profiles/nis/REQUIREMENTS
@@ -4,6 +4,9 @@ Make sure that NIS service is configured and enabled. See NIS documentation for 
                                                                                           {include if "with-pam-u2f"}
 - with-pam-u2f is selected, make sure that the pam u2f module is installed                {include if "with-pam-u2f"}
   - users can then configure keys using the pamu2fcfg tool                                {include if "with-pam-u2f"}
+                                                                                          {include if "with-pam-gnome-keyring"}
+- with-pam-gnome-keyring is selected, make sure the pam_gnome_keyring module              {include if "with-pam-gnome-keyring"}
+  is present.                                                                             {include if "with-pam-gnome-keyring"}
                                                                                           {include if "with-pam-u2f-2fa"}
 - with-pam-u2f-2fa is selected, make sure that the pam u2f module is installed            {include if "with-pam-u2f-2fa"}
   - users can then configure keys using the pamu2fcfg tool                                {include if "with-pam-u2f-2fa"}

--- a/profiles/nis/fingerprint-auth
+++ b/profiles/nis/fingerprint-auth
@@ -4,6 +4,7 @@ auth        required                                     pam_env.so
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
 auth        [success=done default=bad]                   pam_fprintd.so
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
+auth        optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
@@ -19,3 +20,4 @@ session     optional                                     pam_ecryptfs.so unwrap 
 session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
+session     optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}

--- a/profiles/nis/password-auth
+++ b/profiles/nis/password-auth
@@ -5,6 +5,7 @@ auth        sufficient                                   pam_u2f.so cue         
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
 auth        required                                     pam_faillock.so authfail                                 {include if "with-faillock"}
+auth        optional                                     pam_gnome_keyring.so only_if=login auto_start            {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                            {include if "with-pamaccess"}
@@ -22,3 +23,4 @@ session     optional                                     pam_ecryptfs.so unwrap 
 session     optional                                     pam_oddjob_mkhomedir.so                                 {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
+session     optional                                     pam_gnome_keyring.so only_if=login auto_start           {include if "with-pam-gnome-keyring"}

--- a/profiles/nis/system-auth
+++ b/profiles/nis/system-auth
@@ -6,6 +6,7 @@ auth        sufficient                                   pam_u2f.so cue         
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
+auth        optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
@@ -23,3 +24,4 @@ session     optional                                     pam_ecryptfs.so unwrap 
 session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
+session     optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}

--- a/profiles/sssd/README
+++ b/profiles/sssd/README
@@ -58,6 +58,9 @@ with-smartcard-required::
 with-fingerprint::
     Enable authentication with fingerprint reader through *pam_fprintd*.
 
+with-pam-gnome-keyring::
+    Enable pam-gnome-keyring support.
+
 with-pam-u2f::
     Enable authentication via u2f dongle through *pam_u2f*.
 

--- a/profiles/sssd/REQUIREMENTS
+++ b/profiles/sssd/REQUIREMENTS
@@ -4,6 +4,9 @@ Make sure that SSSD service is configured and enabled. See SSSD documentation fo
   - set "pam_cert_auth = True" in [pam] section                                           {include if "with-smartcard"}
                                                                                           {include if "with-fingerprint"}
 - with-fingerprint is selected, make sure fprintd service is configured and enabled       {include if "with-fingerprint"}
+                                                                                          {include if "with-pam-gnome-keyring"}
+- with-pam-gnome-keyring is selected, make sure the pam_gnome_keyring module              {include if "with-pam-gnome-keyring"}
+  is present.                                                                             {include if "with-pam-gnome-keyring"}
                                                                                           {include if "with-pam-u2f"}
 - with-pam-u2f is selected, make sure that the pam u2f module is installed                {include if "with-pam-u2f"}
   - users can then configure keys using the pamu2fcfg tool                                {include if "with-pam-u2f"}

--- a/profiles/sssd/fingerprint-auth
+++ b/profiles/sssd/fingerprint-auth
@@ -5,6 +5,7 @@ auth        required                                     pam_deny.so # Smartcard
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
 auth        [success=done default=bad]                   pam_fprintd.so
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
+auth        optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
@@ -25,3 +26,4 @@ session     optional                                     pam_oddjob_mkhomedir.so
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
 session     optional                                     pam_sss.so
+session     optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}

--- a/profiles/sssd/password-auth
+++ b/profiles/sssd/password-auth
@@ -10,6 +10,7 @@ auth        sufficient                                   pam_unix.so {if not "wi
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_sss.so forward_pass
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
+auth        optional                                     pam_gnome_keyring.so auto_start                        {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
@@ -33,3 +34,4 @@ session     optional                                     pam_oddjob_mkhomedir.so
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
 session     optional                                     pam_sss.so
+session     optional                                     pam_gnome_keyring.so auto_start                        {include if "with-pam-gnome-keyring"}

--- a/profiles/sssd/smartcard-auth
+++ b/profiles/sssd/smartcard-auth
@@ -5,6 +5,7 @@ auth        required                                     pam_env.so
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
 auth        sufficient                                   pam_sss.so allow_missing_name {if "with-smartcard-required":require_cert_auth}
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
+auth        optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
@@ -23,3 +24,4 @@ session     optional                                     pam_oddjob_mkhomedir.so
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
 session     optional                                     pam_sss.so
+session     optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}

--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -15,6 +15,7 @@ auth        sufficient                                   pam_unix.so {if not "wi
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_sss.so forward_pass
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
+auth        optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
@@ -38,3 +39,4 @@ session     optional                                     pam_oddjob_mkhomedir.so
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
 session     optional                                     pam_sss.so
+session     optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}

--- a/profiles/winbind/README
+++ b/profiles/winbind/README
@@ -39,6 +39,9 @@ with-ecryptfs::
 with-fingerprint::
     Enable authentication with fingerprint reader through *pam_fprintd*.
 
+with-pam-gnome-keyring::
+    Enable pam-gnome-keyring support.
+
 with-pam-u2f::
     Enable authentication via u2f dongle through *pam_u2f*.
 

--- a/profiles/winbind/REQUIREMENTS
+++ b/profiles/winbind/REQUIREMENTS
@@ -1,6 +1,9 @@
 Make sure that winbind service is configured and enabled. See winbind documentation for more information.
                                                                                           {include if "with-fingerprint"}
 - with-fingerprint is selected, make sure fprintd service is configured and enabled       {include if "with-fingerprint"}
+                                                                                          {include if "with-pam-gnome-keyring"}
+- with-pam-gnome-keyring is selected, make sure the pam_gnome_keyring module              {include if "with-pam-gnome-keyring"}
+  is present.                                                                             {include if "with-pam-gnome-keyring"}
                                                                                           {include if "with-pam-u2f"}
 - with-pam-u2f is selected, make sure that the pam u2f module is installed                {include if "with-pam-u2f"}
   - users can then configure keys using the pamu2fcfg tool                                {include if "with-pam-u2f"}

--- a/profiles/winbind/fingerprint-auth
+++ b/profiles/winbind/fingerprint-auth
@@ -4,6 +4,7 @@ auth        required                                     pam_env.so
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
 auth        [success=done default=bad]                   pam_fprintd.so
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
+auth        optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
@@ -24,3 +25,4 @@ session     optional                                     pam_oddjob_mkhomedir.so
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
 session     optional                                     pam_winbind.so {if "with-krb5":krb5_auth}
+session     optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}

--- a/profiles/winbind/password-auth
+++ b/profiles/winbind/password-auth
@@ -7,6 +7,7 @@ auth        sufficient                                   pam_unix.so {if not "wi
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_first_pass
 auth        required                                     pam_faillock.so authfail                                 {include if "with-faillock"}
+auth        optional                                     pam_gnome_keyring.so only_if=login auto_start            {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                            {include if "with-pamaccess"}
@@ -30,3 +31,4 @@ session     optional                                     pam_oddjob_mkhomedir.so
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
 session     optional                                     pam_winbind.so {if "with-krb5":krb5_auth}
+session     optional                                     pam_gnome_keyring.so only_if=login auto_start           {include if "with-pam-gnome-keyring"}

--- a/profiles/winbind/system-auth
+++ b/profiles/winbind/system-auth
@@ -8,6 +8,7 @@ auth        sufficient                                   pam_unix.so {if not "wi
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_first_pass
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
+auth        optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
@@ -31,3 +32,4 @@ session     optional                                     pam_oddjob_mkhomedir.so
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
 session     optional                                     pam_winbind.so {if "with-krb5":krb5_auth}
+session     optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}


### PR DESCRIPTION
Currently the default profiles don't have the ability to enable the use of pam_gnome_keyring module.  This update adds a 'with-pam-gnome-keyring' feature to the default profiles.

The feature does not enable the feature by default.  

This update should have no impact on current installs.  This an opt-in feature.