### PR TITLE
Add switch for pam_oath (oathtoolkit)

### DIFF
--- a/profiles/minimal/README
+++ b/profiles/minimal/README
@@ -26,6 +26,10 @@ with-mkhomedir::
 with-ecryptfs::
     Enable automatic per-user ecryptfs.
 
+with-oathtool::
+    Enable authentication with oathtool secrets through *pam_oath*.
+    User secrets expected in /etc/users.oath
+
 with-silent-lastlog::
     Do not produce pam_lastlog message during login.
 

--- a/profiles/minimal/REQUIREMENTS
+++ b/profiles/minimal/REQUIREMENTS
@@ -1,5 +1,7 @@
 - with-mkhomedir is selected, make sure pam_oddjob_mkhomedir module                       {include if "with-mkhomedir"}
   is present and oddjobd service is enabled and active                                    {include if "with-mkhomedir"}
   - systemctl enable --now oddjobd.service                                                {include if "with-mkhomedir"}
-                                                                                          {include if "with-mkhomedir"}
+                                                                                          {include if "with-altfiles"}
 - with-altfiles is selected, make sure nss_altfiles module is present                     {include if "with-altfiles"}
+                                                                                          {include if "with-oathtool"}
+- with-oathtool is selected, make sure /etc/users.oath is present                         {include if "with-oathtool"}

--- a/profiles/minimal/password-auth
+++ b/profiles/minimal/password-auth
@@ -2,6 +2,7 @@ auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
+auth        [user_unknown=ignore success=done]           pam_oath.so usersfile=/etc/users.oath                  {include if "with-oathtool"}
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so
 

--- a/profiles/minimal/system-auth
+++ b/profiles/minimal/system-auth
@@ -2,6 +2,7 @@ auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
+auth        [user_unknown=ignore success=done]           pam_oath.so usersfile=/etc/users.oath                  {include if "with-oathtool"}
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so
 

--- a/profiles/nis/README
+++ b/profiles/nis/README
@@ -24,6 +24,10 @@ with-mkhomedir::
 with-ecryptfs::
     Enable automatic per-user ecryptfs.
 
+with-oathtool::
+    Enable authentication with oathtool secrets through *pam_oath*.
+    User secrets expected in /etc/users.oath
+
 with-fingerprint::
     Enable authentication with fingerprint reader through *pam_fprintd*.
 

--- a/profiles/nis/REQUIREMENTS
+++ b/profiles/nis/REQUIREMENTS
@@ -1,6 +1,8 @@
 Make sure that NIS service is configured and enabled. See NIS documentation for more information.
                                                                                           {include if "with-fingerprint"}
 - with-fingerprint is selected, make sure fprintd service is configured and enabled       {include if "with-fingerprint"}
+                                                                                          {include if "with-oathtool"}
+- with-oathtool is selected, make sure /etc/users.oath is present                         {include if "with-oathtool"}
                                                                                           {include if "with-pam-u2f"}
 - with-pam-u2f is selected, make sure that the pam u2f module is installed                {include if "with-pam-u2f"}
   - users can then configure keys using the pamu2fcfg tool                                {include if "with-pam-u2f"}

--- a/profiles/nis/password-auth
+++ b/profiles/nis/password-auth
@@ -5,6 +5,7 @@ auth        sufficient                                   pam_u2f.so cue         
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
 auth        sufficient                                   pam_systemd_home.so                                      {include if "with-systemd-homed"}
+auth        [user_unknown=ignore success=done]           pam_oath.so usersfile=/etc/users.oath                    {include if "with-oathtool"}
 auth        required                                     pam_faillock.so authfail                                 {include if "with-faillock"}
 auth        optional                                     pam_gnome_keyring.so only_if=login auto_start            {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so

--- a/profiles/nis/system-auth
+++ b/profiles/nis/system-auth
@@ -6,6 +6,7 @@ auth        sufficient                                   pam_u2f.so cue         
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
 auth        sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
+auth        [user_unknown=ignore success=done]           pam_oath.so usersfile=/etc/users.oath                  {include if "with-oathtool"}
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so

--- a/profiles/sssd/README
+++ b/profiles/sssd/README
@@ -50,6 +50,10 @@ with-smartcard-required::
     Smartcard authentication is required. No other means of authentication
     (including password) will be enabled.
 
+with-oathtool::
+    Enable authentication with oathtool secrets through *pam_oath*.
+    User secrets expected in /etc/users.oath
+
 with-fingerprint::
     Enable authentication with fingerprint reader through *pam_fprintd*.
 

--- a/profiles/sssd/REQUIREMENTS
+++ b/profiles/sssd/REQUIREMENTS
@@ -4,6 +4,8 @@ Make sure that SSSD service is configured and enabled. See SSSD documentation fo
   - set "pam_cert_auth = True" in [pam] section                                           {include if "with-smartcard"}
                                                                                           {include if "with-fingerprint"}
 - with-fingerprint is selected, make sure fprintd service is configured and enabled       {include if "with-fingerprint"}
+                                                                                          {include if "with-oathtool"}
+- with-oathtool is selected, make sure /etc/users.oath is present                         {include if "with-oathtool"}
                                                                                           {include if "with-pam-gnome-keyring"}
 - with-pam-gnome-keyring is selected, make sure the pam_gnome_keyring module              {include if "with-pam-gnome-keyring"}
   is present.                                                                             {include if "with-pam-gnome-keyring"}

--- a/profiles/sssd/password-auth
+++ b/profiles/sssd/password-auth
@@ -10,6 +10,7 @@ auth        sufficient                                   pam_unix.so {if not "wi
 auth        sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_sss.so forward_pass
+auth        [user_unknown=ignore success=done]           pam_oath.so usersfile=/etc/users.oath                  {include if "with-oathtool"}
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        optional                                     pam_gnome_keyring.so auto_start                        {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so

--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -17,6 +17,7 @@ auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregul
 auth        sufficient                                   pam_sss_gss.so                                         {include if "with-gssapi"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_sss.so forward_pass
+auth        [user_unknown=ignore success=done]           pam_oath.so usersfile=/etc/users.oath                  {include if "with-oathtool"}
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so

--- a/profiles/winbind/README
+++ b/profiles/winbind/README
@@ -36,6 +36,10 @@ with-mkhomedir::
 with-ecryptfs::
     Enable automatic per-user ecryptfs.
 
+with-oathtool::
+    Enable authentication with oathtool secrets through *pam_oath*.
+    User secrets expected in /etc/users.oath
+
 with-fingerprint::
     Enable authentication with fingerprint reader through *pam_fprintd*.
 

--- a/profiles/winbind/REQUIREMENTS
+++ b/profiles/winbind/REQUIREMENTS
@@ -1,6 +1,8 @@
 Make sure that winbind service is configured and enabled. See winbind documentation for more information.
                                                                                           {include if "with-fingerprint"}
 - with-fingerprint is selected, make sure fprintd service is configured and enabled       {include if "with-fingerprint"}
+                                                                                          {include if "with-oathtool"}
+- with-oathtool is selected, make sure /etc/users.oath is present                         {include if "with-oathtool"}
                                                                                           {include if "with-pam-gnome-keyring"}
 - with-pam-gnome-keyring is selected, make sure the pam_gnome_keyring module              {include if "with-pam-gnome-keyring"}
   is present.                                                                             {include if "with-pam-gnome-keyring"}

--- a/profiles/winbind/password-auth
+++ b/profiles/winbind/password-auth
@@ -7,6 +7,7 @@ auth        sufficient                                   pam_unix.so {if not "wi
 auth        sufficient                                   pam_systemd_home.so                                      {include if "with-systemd-homed"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_first_pass
+auth        [user_unknown=ignore success=done]           pam_oath.so usersfile=/etc/users.oath                    {include if "with-oathtool"}
 auth        required                                     pam_faillock.so authfail                                 {include if "with-faillock"}
 auth        optional                                     pam_gnome_keyring.so only_if=login auto_start            {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so

--- a/profiles/winbind/system-auth
+++ b/profiles/winbind/system-auth
@@ -8,6 +8,7 @@ auth        sufficient                                   pam_unix.so {if not "wi
 auth        sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_first_pass
+auth        [user_unknown=ignore success=done]           pam_oath.so usersfile=/etc/users.oath                  {include if "with-oathtool"}
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so


### PR DESCRIPTION
This adds way for the default profiles to add the oath-toolkit one time password scheme.

https://www.nongnu.org/oath-toolkit/pam_oath.html
https://koji.fedoraproject.org/koji/packageinfo?packageID=16336

They could probably use a bit of review as my understanding of pam is limited.