### PR TITLE
sssd: Allow users unknown to sssd to authenticate

### DIFF
--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -10,7 +10,7 @@ auth        required                                     pam_u2f.so cue {if not 
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        [default=1 ignore=ignore success=ok]         pam_localuser.so                                       {exclude if "with-smartcard"}
 auth        [default=2 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-smartcard"}
-auth        [success=done authinfo_unavail=ignore ignore=ignore default=die] pam_sss.so try_cert_auth           {include if "with-smartcard"}
+auth        [success=done authinfo_unavail=ignore user_unknown=ignore ignore=ignore default=die] pam_sss.so try_cert_auth {include if "with-smartcard"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular                              {include if "with-gssapi"}
 auth        sufficient                                   pam_sss_gss.so                                         {include if "with-gssapi"}

--- a/src/man/authselect-profiles.5.adoc
+++ b/src/man/authselect-profiles.5.adoc
@@ -193,11 +193,11 @@ previous example.
   auth        required                                     pam_env.so
   auth        required                                     pam_faildelay.so delay=2000000
   auth        [success=1 default=ignore]                   pam_succeed_if.so service notin login:gdm:xdm:kdm:kde:xscreensaver:gnome-screensaver:kscreensaver quiet use_uid {include if "with-smartcard-required"}
-  auth        [success=done ignore=ignore default=die]     pam_sss.so require_cert_auth ignore_authinfo_unavail   {include if "with-smartcard-required"}
+  auth        [success=done ignore=ignore default=die]     pam_sss.so require_cert_auth ignore_authinfo_unavail             {include if "with-smartcard-required"}
   auth        [default=1 ignore=ignore success=ok]         pam_succeed_if.so uid >= 1000 quiet
-  auth        [default=1 ignore=ignore success=ok]         pam_localuser.so                                       {exclude if "with-smartcard"}
-  auth        [default=2 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-smartcard"}
-  auth        [success=done authinfo_unavail=ignore ignore=ignore default=die] pam_sss.so try_cert_auth           {include if "with-smartcard"}
+  auth        [default=1 ignore=ignore success=ok]         pam_localuser.so                                                 {exclude if "with-smartcard"}
+  auth        [default=2 ignore=ignore success=ok]         pam_localuser.so                                                 {include if "with-smartcard"}
+  auth        [success=done authinfo_unavail=ignore user_unknown=ignore ignore=ignore default=die] pam_sss.so try_cert_auth {include if "with-smartcard"}
   auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
   auth        requisite                                    pam_succeed_if.so uid >= 1000 quiet_success
   auth        sufficient                                   pam_sss.so forward_pass


### PR DESCRIPTION
On EL8 with:
```
Profile ID: sssd
Enabled features:
- with-smartcard
- with-smartcard-lock-on-removal
- with-sudo
- with-custom-automount
```
A local user (tempmon uid 1000 in /etc/passwd) cannot access cron:
```
You (tempmon) are not allowed to access to (crontab) because of pam configuration.
```
pam_sssd:
```
[pam_reply] (0x0200): Returning [10]: User not known to the underlying authentication module to the client [CID #2872]
```
I'm not entirely sure that this is the proper fix, but it seems likely.