### PR TITLE
lib: correctly restore authselect backup

### DIFF
--- a/src/lib/authselect_backup.c
+++ b/src/lib/authselect_backup.c
@@ -287,6 +287,16 @@ authselect_restore_authselect_configuration(const char *path)
         {FILE_NSSWITCH,    PATH_NSSWITCH, false},
         {FILE_DCONF_DB,    PATH_DCONF_DB, false},
         {FILE_DCONF_LOCK,  PATH_DCONF_LOCK, false},
+
+        {FILE_SYSTEM,      PATH_COPY_SYSTEM, false},
+        {FILE_PASSWORD,    PATH_COPY_PASSWORD, false},
+        {FILE_FINGERPRINT, PATH_COPY_FINGERPRINT, false},
+        {FILE_SMARTCARD,   PATH_COPY_SMARTCARD, false},
+        {FILE_POSTLOGIN,   PATH_COPY_POSTLOGIN, false},
+        {FILE_NSSWITCH,    PATH_COPY_NSSWITCH, false},
+        {FILE_DCONF_DB,    PATH_COPY_DCONF_DB, false},
+        {FILE_DCONF_LOCK,  PATH_COPY_DCONF_LOCK, false},
+
         {NULL, NULL, false},
     };
     errno_t ret;


### PR DESCRIPTION
The restore process did not write configuration copy to
/var/lib/authselect which made the restoration incomplete
and `authselect check` then failed.

Steps to reproduce:
1. authselect select sssd --force
2. authselect enable-feature with-mkhomedir
3. authselect apply-changes --backup=test
4. authselect backup-restore test
5. authselect check

`authselect check` will fail without this patch.

Resolves: https://github.com/authselect/authselect/issues/302