### PR TITLE
Homed flags

### DIFF
--- a/profiles/nis/README
+++ b/profiles/nis/README
@@ -62,6 +62,9 @@ with-mdns4::
 with-mdns6::
     Enable multicast DNS over IPv6.
 
+with-systemd-homed
+    If set, pam_systemd_homed is enabled for all pam operations.
+
 without-nullok::
     Do not add nullok parameter to pam_unix.
 

--- a/profiles/nis/REQUIREMENTS
+++ b/profiles/nis/REQUIREMENTS
@@ -14,3 +14,6 @@ Make sure that NIS service is configured and enabled. See NIS documentation for 
 - with-mkhomedir is selected, make sure pam_oddjob_mkhomedir module                       {include if "with-mkhomedir"}
   is present and oddjobd service is enabled and active                                    {include if "with-mkhomedir"}
   - systemctl enable --now oddjobd.service                                                {include if "with-mkhomedir"}
+
+- with-homed is selected, make sure that the system-homed service is enabled              {include if "with-homed"}
+  - systemctl enable --now systemd-homed.service                                          {include if "with-homed"}

--- a/profiles/nis/password-auth
+++ b/profiles/nis/password-auth
@@ -4,14 +4,17 @@ auth        required                                     pam_faillock.so preauth
 auth        sufficient                                   pam_u2f.so cue                                           {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
+-auth       sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 auth        required                                     pam_faillock.so authfail                                 {include if "with-faillock"}
 auth        optional                                     pam_gnome_keyring.so only_if=login auto_start            {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                            {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                          {include if "with-faillock"}
+-account    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 account     required                                     pam_unix.so broken_shadow
 
+-password   sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 password    requisite                                    pam_pwquality.so {if not "with-nispwquality":local_users_only}
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok nis
 password    required                                     pam_deny.so
@@ -19,6 +22,7 @@ password    required                                     pam_deny.so
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                  {include if "with-ecryptfs"}
+-session    optional                                     pam_systemd_home.so                                    {include if "with-systemd-homed"}
 -session    optional                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so                                 {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid

--- a/profiles/nis/system-auth
+++ b/profiles/nis/system-auth
@@ -5,14 +5,17 @@ auth        sufficient                                   pam_fprintd.so         
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
+-auth       sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
+-account    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 account     required                                     pam_unix.so broken_shadow
 
+-password    sufficient                                  pam_systemd_home.so                                   {include if "with-systemd-homed"}
 password    requisite                                    pam_pwquality.so {if not "with-nispwquality":local_users_only}
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok nis
 password    required                                     pam_deny.so
@@ -20,6 +23,7 @@ password    required                                     pam_deny.so
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
+-session    optional                                     pam_systemd_home.so                                    {include if "with-systemd-homed"}
 -session    optional                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid

--- a/profiles/sssd/README
+++ b/profiles/sssd/README
@@ -113,6 +113,9 @@ with-gssapi::
 with-subid::
     Enable SSSD as a source of subid database in /etc/nsswitch.conf.
 
+with-systemd-homed
+    If set, pam_systemd_homed is enabled for all pam operations.
+
 without-nullok::
     Do not add nullok parameter to pam_unix.
 

--- a/profiles/sssd/REQUIREMENTS
+++ b/profiles/sssd/REQUIREMENTS
@@ -25,3 +25,6 @@ Make sure that SSSD service is configured and enabled. See SSSD documentation fo
 - with-gssapi is selected, make sure that GSSAPI authenticaiton is enabled in SSSD        {include if "with-gssapi"}
   - set pam_gssapi_services to a list of allowed services in /etc/sssd/sssd.conf          {include if "with-gssapi"}
   - see additional information in pam_sss_gss(8)                                          {include if "with-gssapi"}
+
+- with-homed is selected, make sure that the system-homed service is enabled              {include if "with-homed"}
+  - systemctl enable --now systemd-homed.service                                          {include if "with-homed"}

--- a/profiles/sssd/password-auth
+++ b/profiles/sssd/password-auth
@@ -7,6 +7,7 @@ auth        required                                     pam_u2f.so cue {if not 
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        [default=1 ignore=ignore success=ok]         pam_localuser.so
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
+-auth       sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_sss.so forward_pass
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
@@ -15,12 +16,14 @@ auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
+-account    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 account     required                                     pam_unix.so
 account     sufficient                                   pam_localuser.so                                       {exclude if "with-files-access-provider"}
 account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 account     required                                     pam_permit.so
 
+-password   sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 password    requisite                                    pam_pwquality.so local_users_only
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
 password    sufficient                                   pam_sss.so use_authtok
@@ -28,9 +31,10 @@ password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
-session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
+session     optional                                     pam_ecryptfs.so unwrap                                 {include if "with-ecryptfs"}
+-session    optional                                     pam_systemd_home.so                                    {include if "with-systemd-homed"}
 -session    optional                                     pam_systemd.so
-session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
+session     optional                                     pam_oddjob_mkhomedir.so                                {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
 session     optional                                     pam_sss.so

--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -12,6 +12,7 @@ auth        [default=1 ignore=ignore success=ok]         pam_localuser.so       
 auth        [default=2 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-smartcard"}
 auth        [success=done authinfo_unavail=ignore user_unknown=ignore ignore=ignore default=die] pam_sss.so try_cert_auth {include if "with-smartcard"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
+-auth       sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular                              {include if "with-gssapi"}
 auth        sufficient                                   pam_sss_gss.so                                         {include if "with-gssapi"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
@@ -22,12 +23,14 @@ auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
+-account    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 account     required                                     pam_unix.so
 account     sufficient                                   pam_localuser.so                                       {exclude if "with-files-access-provider"}
 account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 account     required                                     pam_permit.so
 
+-password    sufficient                                  pam_systemd_home.so                                   {include if "with-systemd-homed"}
 password    requisite                                    pam_pwquality.so local_users_only
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
 password    sufficient                                   pam_sss.so use_authtok
@@ -35,9 +38,10 @@ password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
-session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
+session     optional                                     pam_ecryptfs.so unwrap                                 {include if "with-ecryptfs"}
+-session    optional                                     pam_systemd_home.so                                    {include if "with-systemd-homed"}
 -session    optional                                     pam_systemd.so
-session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
+session     optional                                     pam_oddjob_mkhomedir.so                                {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
 session     optional                                     pam_sss.so

--- a/profiles/winbind/README
+++ b/profiles/winbind/README
@@ -72,6 +72,9 @@ with-mdns4::
 with-mdns6::
     Enable multicast DNS over IPv6.
 
+with-systemd-homed
+    If set, pam_systemd_homed is enabled for all pam operations.
+
 without-nullok::
     Do not add nullok parameter to pam_unix.
 

--- a/profiles/winbind/REQUIREMENTS
+++ b/profiles/winbind/REQUIREMENTS
@@ -14,3 +14,6 @@ Make sure that winbind service is configured and enabled. See winbind documentat
 - with-mkhomedir is selected, make sure pam_oddjob_mkhomedir module                       {include if "with-mkhomedir"}
   is present and oddjobd service is enabled and active                                    {include if "with-mkhomedir"}
   - systemctl enable --now oddjobd.service                                                {include if "with-mkhomedir"}
+
+- with-homed is selected, make sure that the system-homed service is enabled              {include if "with-homed"}
+  - systemctl enable --now systemd-homed.service                                          {include if "with-homed"}

--- a/profiles/winbind/password-auth
+++ b/profiles/winbind/password-auth
@@ -4,6 +4,7 @@ auth        required                                     pam_faillock.so preauth
 auth        sufficient                                   pam_u2f.so cue                                           {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
+-auth       sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_first_pass
 auth        required                                     pam_faillock.so authfail                                 {include if "with-faillock"}
@@ -12,12 +13,14 @@ auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                            {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                          {include if "with-faillock"}
+-account    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 account     required                                     pam_unix.so broken_shadow
 account     sufficient                                   pam_localuser.so
 account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_winbind.so {if "with-krb5":krb5_auth}
 account     required                                     pam_permit.so
 
+-password   sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 password    requisite                                    pam_pwquality.so local_users_only
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
 password    sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_authtok
@@ -26,6 +29,7 @@ password    required                                     pam_deny.so
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                  {include if "with-ecryptfs"}
+-session    optional                                     pam_systemd_home.so                                    {include if "with-systemd-homed"}
 -session    optional                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so                                 {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid

--- a/profiles/winbind/system-auth
+++ b/profiles/winbind/system-auth
@@ -5,6 +5,7 @@ auth        sufficient                                   pam_fprintd.so         
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
+-auth       sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_first_pass
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
@@ -13,12 +14,14 @@ auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
+-account    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 account     required                                     pam_unix.so broken_shadow
 account     sufficient                                   pam_localuser.so
 account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_winbind.so {if "with-krb5":krb5_auth}
 account     required                                     pam_permit.so
 
+-password    sufficient                                  pam_systemd_home.so                                   {include if "with-systemd-homed"}
 password    requisite                                    pam_pwquality.so local_users_only
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
 password    sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_authtok
@@ -27,6 +30,7 @@ password    required                                     pam_deny.so
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
+-session    optional                                     pam_systemd_home.so                                    {include if "with-systemd-homed"}
 -session    optional                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid


### PR DESCRIPTION
Add a flag and pam config that allows homed created users to login via the CLI and graphical login screen.