### PR TITLE
man: remove --custom from create-profile which does not exist

### DIFF
--- a/src/man/authselect.8.adoc
+++ b/src/man/authselect.8.adoc
@@ -181,7 +181,7 @@ To print help for the selected command run *authselect COMMAND --help*.
         be stored at {AUTHSELECT_BACKUP_DIR}/NAME. Current time with unique
         string is used as a name if no value is provided.
 
-*create-profile* NAME [--custom,-c|--vendor,-v] [options]::
+*create-profile* NAME [--vendor,-v] [options]::
     Create a new custom profile named _NAME_. The profile can be based on an
     existing profile in which case the new profile templates are either copied
     from the base profile or symbolic links to these files are created if


### PR DESCRIPTION
Resolves: https://github.com/authselect/authselect/issues/315