### PR TITLE
profiles: Add with-libvirt feature

### DIFF
--- a/profiles/nis/README
+++ b/profiles/nis/README
@@ -65,6 +65,10 @@ with-mdns6::
 without-nullok::
     Do not add nullok parameter to pam_unix.
 
+with-libvirt::
+    Enable connecting to libvirt VMs using the hostname configured in the
+    guest OS or, as a fallback, their name.
+
 EXAMPLES
 --------
 * Enable NIS with no additional modules

--- a/profiles/nis/REQUIREMENTS
+++ b/profiles/nis/REQUIREMENTS
@@ -14,3 +14,5 @@ Make sure that NIS service is configured and enabled. See NIS documentation for 
 - with-mkhomedir is selected, make sure pam_oddjob_mkhomedir module                       {include if "with-mkhomedir"}
   is present and oddjobd service is enabled and active                                    {include if "with-mkhomedir"}
   - systemctl enable --now oddjobd.service                                                {include if "with-mkhomedir"}
+                                                                                          {include if "with-libvirt"}
+- with-libvirt is selected, make sure that the libvirt NSS plugins are installed          {include if "with-libvirt"}

--- a/profiles/nis/nsswitch.conf
+++ b/profiles/nis/nsswitch.conf
@@ -2,7 +2,7 @@
 passwd:     files {if "with-altfiles":altfiles }nis systemd
 shadow:     files nis
 group:      files {if "with-altfiles":altfiles }nis systemd
-hosts:      files myhostname {if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] nis dns
+hosts:      files myhostname {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] nis dns
 services:   files nis
 netgroup:   files nis
 automount:  files nis

--- a/profiles/sssd/README
+++ b/profiles/sssd/README
@@ -116,6 +116,10 @@ with-subid::
 without-nullok::
     Do not add nullok parameter to pam_unix.
 
+with-libvirt::
+    Enable connecting to libvirt VMs using the hostname configured in the
+    guest OS or, as a fallback, their name.
+
 EXAMPLES
 --------
 

--- a/profiles/sssd/REQUIREMENTS
+++ b/profiles/sssd/REQUIREMENTS
@@ -25,3 +25,5 @@ Make sure that SSSD service is configured and enabled. See SSSD documentation fo
 - with-gssapi is selected, make sure that GSSAPI authenticaiton is enabled in SSSD        {include if "with-gssapi"}
   - set pam_gssapi_services to a list of allowed services in /etc/sssd/sssd.conf          {include if "with-gssapi"}
   - see additional information in pam_sss_gss(8)                                          {include if "with-gssapi"}
+                                                                                          {include if "with-libvirt"}
+- with-libvirt is selected, make sure that the libvirt NSS plugins are installed          {include if "with-libvirt"}

--- a/profiles/sssd/nsswitch.conf
+++ b/profiles/sssd/nsswitch.conf
@@ -2,7 +2,7 @@
 passwd:     {if "with-files-domain":sss }files {if "with-altfiles":altfiles }{if not "with-files-domain":sss }systemd
 shadow:     files
 group:      {if "with-files-domain":sss }files {if "with-altfiles":altfiles }{if not "with-files-domain":sss }systemd
-hosts:      files myhostname {if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] dns
+hosts:      files myhostname {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] dns
 services:   files sss
 netgroup:   files sss
 sudoers:    files sss {include if "with-sudo"}

--- a/profiles/winbind/README
+++ b/profiles/winbind/README
@@ -75,6 +75,10 @@ with-mdns6::
 without-nullok::
     Do not add nullok parameter to pam_unix.
 
+with-libvirt::
+    Enable connecting to libvirt VMs using the hostname configured in the
+    guest OS or, as a fallback, their name.
+
 EXAMPLES
 --------
 * Enable winbind with no additional modules

--- a/profiles/winbind/REQUIREMENTS
+++ b/profiles/winbind/REQUIREMENTS
@@ -14,3 +14,5 @@ Make sure that winbind service is configured and enabled. See winbind documentat
 - with-mkhomedir is selected, make sure pam_oddjob_mkhomedir module                       {include if "with-mkhomedir"}
   is present and oddjobd service is enabled and active                                    {include if "with-mkhomedir"}
   - systemctl enable --now oddjobd.service                                                {include if "with-mkhomedir"}
+                                                                                          {include if "with-libvirt"}
+- with-libvirt is selected, make sure that the libvirt NSS plugins are installed          {include if "with-libvirt"}

--- a/profiles/winbind/nsswitch.conf
+++ b/profiles/winbind/nsswitch.conf
@@ -2,7 +2,7 @@
 passwd:     files {if "with-altfiles":altfiles }winbind systemd
 shadow:     files
 group:      files {if "with-altfiles":altfiles }winbind systemd
-hosts:      files myhostname {if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] dns
+hosts:      files myhostname {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] dns
 services:   files
 netgroup:   files
 automount:  files


### PR DESCRIPTION
The libvirt NSS plugins can be used to conveniently connect to VMs running on the system.

See [https://libvirt.org/nss.html](https://libvirt.org/nss.html) for additional information. Once this is merged, I will update that page to advertise authselect as the preferred mechanism to enable the feature.

This is my first time contributing to authselect, so please don't hesitate to point out any mistake I might have made :)