### PR TITLE
profiles: add "with-systemd-home" feature

### DIFF
--- a/profiles/minimal/README
+++ b/profiles/minimal/README
@@ -44,6 +44,9 @@ with-mdns6::
 without-nullok::
     Do not add nullok parameter to pam_unix.
 
+with-systemd-home::
+    Enable authentication of home directories for users of systemd
+    
 EXAMPLES
 --------
 

--- a/profiles/minimal/REQUIREMENTS
+++ b/profiles/minimal/REQUIREMENTS
@@ -1,5 +1,10 @@
+                                                                                          {include if "with-mkhomedir"}
 - with-mkhomedir is selected, make sure pam_oddjob_mkhomedir module                       {include if "with-mkhomedir"}
   is present and oddjobd service is enabled and active                                    {include if "with-mkhomedir"}
   - systemctl enable --now oddjobd.service                                                {include if "with-mkhomedir"}
-                                                                                          {include if "with-mkhomedir"}
+                                                                                          {include if "with-altfiles"}
 - with-altfiles is selected, make sure nss_altfiles module is present                     {include if "with-altfiles"}
+                                                                                          {include if "with-systemd-home"}
+- with-systemd-home selected, make sure pam_systemd_home module                           {include if "with-systemd-home"}
+  is present and systemd-homed service is enabled and active.                             {include if "with-systemd-home"}
+  - systemctl enable --now systemd-homed.service                                          {include if "with-systemd-home"}

--- a/profiles/minimal/password-auth
+++ b/profiles/minimal/password-auth
@@ -2,13 +2,16 @@ auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
+-auth       sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-home"}
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
+-account    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-home"}
 account     required                                     pam_unix.so
 
+-password   sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-home"}
 password    requisite                                    pam_pwquality.so
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
 password    required                                     pam_deny.so
@@ -16,6 +19,7 @@ password    required                                     pam_deny.so
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
+-session    optional                                     pam_systemd_home.so                                   {include if "with-systemd-home"}
 -session    optional                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid

--- a/profiles/minimal/system-auth
+++ b/profiles/minimal/system-auth
@@ -2,13 +2,16 @@ auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
+-auth       sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-home"}
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
+-account    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-home"}
 account     required                                     pam_unix.so
 
+-password   sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-home"}
 password    requisite                                    pam_pwquality.so
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
 password    required                                     pam_deny.so
@@ -16,6 +19,7 @@ password    required                                     pam_deny.so
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
+-session    optional                                     pam_systemd_home.so                                   {include if "with-systemd-home"}
 -session    optional                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid

--- a/profiles/nis/README
+++ b/profiles/nis/README
@@ -69,6 +69,9 @@ with-libvirt::
     Enable connecting to libvirt VMs using the hostname configured in the
     guest OS or, as a fallback, their name.
 
+with-systemd-home::
+    Enable authentication of home directories for users of systemd
+    
 EXAMPLES
 --------
 * Enable NIS with no additional modules

--- a/profiles/nis/REQUIREMENTS
+++ b/profiles/nis/REQUIREMENTS
@@ -16,3 +16,7 @@ Make sure that NIS service is configured and enabled. See NIS documentation for 
   - systemctl enable --now oddjobd.service                                                {include if "with-mkhomedir"}
                                                                                           {include if "with-libvirt"}
 - with-libvirt is selected, make sure that the libvirt NSS plugins are installed          {include if "with-libvirt"}
+                                                                                          {include if "with-systemd-home"}
+- with-systemd-home selected, make sure pam_systemd_home module                           {include if "with-systemd-home"}
+  is present and systemd-homed service is enabled and active.                             {include if "with-systemd-home"}
+  - systemctl enable --now systemd-homed.service                                          {include if "with-systemd-home"}

--- a/profiles/nis/password-auth
+++ b/profiles/nis/password-auth
@@ -4,14 +4,17 @@ auth        required                                     pam_faillock.so preauth
 auth        sufficient                                   pam_u2f.so cue                                           {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
+-auth       sufficient                                   pam_systemd_home.so                                      {include if "with-systemd-home"}
 auth        required                                     pam_faillock.so authfail                                 {include if "with-faillock"}
 auth        optional                                     pam_gnome_keyring.so only_if=login auto_start            {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                            {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                          {include if "with-faillock"}
+-account    sufficient                                   pam_systemd_home.so                                      {include if "with-systemd-home"}
 account     required                                     pam_unix.so broken_shadow
 
+-password   sufficient                                   pam_systemd_home.so                                      {include if "with-systemd-home"}
 password    requisite                                    pam_pwquality.so {if not "with-nispwquality":local_users_only}
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok nis
 password    required                                     pam_deny.so
@@ -19,6 +22,7 @@ password    required                                     pam_deny.so
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                  {include if "with-ecryptfs"}
+-session    optional                                     pam_systemd_home.so                                     {include if "with-systemd-home"}
 -session    optional                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so                                 {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid

--- a/profiles/nis/system-auth
+++ b/profiles/nis/system-auth
@@ -5,14 +5,17 @@ auth        sufficient                                   pam_fprintd.so         
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
+-auth       sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-home"}
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
+-account    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-home"}
 account     required                                     pam_unix.so broken_shadow
 
+-password   sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-home"}
 password    requisite                                    pam_pwquality.so {if not "with-nispwquality":local_users_only}
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok nis
 password    required                                     pam_deny.so
@@ -20,6 +23,7 @@ password    required                                     pam_deny.so
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
+-session    optional                                     pam_systemd_home.so                                   {include if "with-systemd-home"}
 -session    optional                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid

--- a/profiles/sssd/README
+++ b/profiles/sssd/README
@@ -120,6 +120,9 @@ with-libvirt::
     Enable connecting to libvirt VMs using the hostname configured in the
     guest OS or, as a fallback, their name.
 
+with-systemd-home::
+    Enable authentication of home directories for users of systemd
+
 EXAMPLES
 --------
 

--- a/profiles/sssd/REQUIREMENTS
+++ b/profiles/sssd/REQUIREMENTS
@@ -27,3 +27,7 @@ Make sure that SSSD service is configured and enabled. See SSSD documentation fo
   - see additional information in pam_sss_gss(8)                                          {include if "with-gssapi"}
                                                                                           {include if "with-libvirt"}
 - with-libvirt is selected, make sure that the libvirt NSS plugins are installed          {include if "with-libvirt"}
+                                                                                          {include if "with-systemd-home"}
+- with-systemd-home selected, make sure pam_systemd_home module                           {include if "with-systemd-home"}
+  is present and systemd-homed service is enabled and active.                             {include if "with-systemd-home"}
+  - systemctl enable --now systemd-homed.service                                          {include if "with-systemd-home"}

--- a/profiles/sssd/password-auth
+++ b/profiles/sssd/password-auth
@@ -7,6 +7,7 @@ auth        required                                     pam_u2f.so cue {if not 
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        [default=1 ignore=ignore success=ok]         pam_localuser.so
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
+-auth       sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-home"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_sss.so forward_pass
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
@@ -15,12 +16,14 @@ auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
+-account    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-home"}
 account     required                                     pam_unix.so
 account     sufficient                                   pam_localuser.so                                       {exclude if "with-files-access-provider"}
 account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 account     required                                     pam_permit.so
 
+-password   sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-home"}
 password    requisite                                    pam_pwquality.so local_users_only
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
 password    sufficient                                   pam_sss.so use_authtok
@@ -29,6 +32,7 @@ password    required                                     pam_deny.so
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
+-session    optional                                     pam_systemd_home.so                                   {include if "with-systemd-home"}
 -session    optional                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid

--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -12,6 +12,7 @@ auth        [default=1 ignore=ignore success=ok]         pam_localuser.so       
 auth        [default=2 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-smartcard"}
 auth        [success=done authinfo_unavail=ignore user_unknown=ignore ignore=ignore default=die] pam_sss.so try_cert_auth {include if "with-smartcard"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
+-auth       sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-home"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular                              {include if "with-gssapi"}
 auth        sufficient                                   pam_sss_gss.so                                         {include if "with-gssapi"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
@@ -22,12 +23,14 @@ auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
+-account    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-home"}
 account     required                                     pam_unix.so
 account     sufficient                                   pam_localuser.so                                       {exclude if "with-files-access-provider"}
 account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 account     required                                     pam_permit.so
 
+-password   sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-home"}
 password    requisite                                    pam_pwquality.so local_users_only
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
 password    sufficient                                   pam_sss.so use_authtok
@@ -36,6 +39,7 @@ password    required                                     pam_deny.so
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
+-session    optional                                     pam_systemd_home.so                                   {include if "with-systemd-home"}
 -session    optional                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid

--- a/profiles/winbind/README
+++ b/profiles/winbind/README
@@ -1,7 +1,8 @@
 Enable winbind for system authentication
 ========================================
 
-Selecting this profile will enable Samba's winbind as the source of identity
+Selecting this profile will enable Samba's winbind as the source of identitywith-systemd-home::
+    Enable authentication of home directories for users of systemd
 and authentication providers.
 
 The Samba standard Windows interoperability suite of utilities allows Linux
@@ -79,6 +80,9 @@ with-libvirt::
     Enable connecting to libvirt VMs using the hostname configured in the
     guest OS or, as a fallback, their name.
 
+with-systemd-home::
+    Enable authentication of home directories for users of systemd
+    
 EXAMPLES
 --------
 * Enable winbind with no additional modules

--- a/profiles/winbind/README
+++ b/profiles/winbind/README
@@ -1,8 +1,7 @@
 Enable winbind for system authentication
 ========================================
 
-Selecting this profile will enable Samba's winbind as the source of identitywith-systemd-home::
-    Enable authentication of home directories for users of systemd
+Selecting this profile will enable Samba's winbind as the source of identity
 and authentication providers.
 
 The Samba standard Windows interoperability suite of utilities allows Linux

--- a/profiles/winbind/REQUIREMENTS
+++ b/profiles/winbind/REQUIREMENTS
@@ -16,3 +16,7 @@ Make sure that winbind service is configured and enabled. See winbind documentat
   - systemctl enable --now oddjobd.service                                                {include if "with-mkhomedir"}
                                                                                           {include if "with-libvirt"}
 - with-libvirt is selected, make sure that the libvirt NSS plugins are installed          {include if "with-libvirt"}
+                                                                                          {include if "with-systemd-home"}
+- with-systemd-home selected, make sure pam_systemd_home module                           {include if "with-systemd-home"}
+  is present and systemd-homed service is enabled and active.                             {include if "with-systemd-home"}
+  - systemctl enable --now systemd-homed.service                                          {include if "with-systemd-home"}

--- a/profiles/winbind/password-auth
+++ b/profiles/winbind/password-auth
@@ -4,6 +4,7 @@ auth        required                                     pam_faillock.so preauth
 auth        sufficient                                   pam_u2f.so cue                                           {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
+-auth       sufficient                                   pam_systemd_home.so debug                              {include if "with-systemd-home"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_first_pass
 auth        required                                     pam_faillock.so authfail                                 {include if "with-faillock"}
@@ -12,12 +13,14 @@ auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                            {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                          {include if "with-faillock"}
+-account    sufficient                                   pam_systemd_home.so debug                              {include if "with-systemd-home"}
 account     required                                     pam_unix.so broken_shadow
 account     sufficient                                   pam_localuser.so
 account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_winbind.so {if "with-krb5":krb5_auth}
 account     required                                     pam_permit.so
 
+-password   sufficient                                   pam_systemd_home.so debug                               {include if "with-systemd-home"}
 password    requisite                                    pam_pwquality.so local_users_only
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
 password    sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_authtok
@@ -26,6 +29,7 @@ password    required                                     pam_deny.so
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                  {include if "with-ecryptfs"}
+-session    optional                                     pam_systemd_home.so  debug                              {include if "with-systemd-home"}
 -session    optional                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so                                 {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid

--- a/profiles/winbind/password-auth
+++ b/profiles/winbind/password-auth
@@ -4,7 +4,7 @@ auth        required                                     pam_faillock.so preauth
 auth        sufficient                                   pam_u2f.so cue                                           {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
--auth       sufficient                                   pam_systemd_home.so debug                              {include if "with-systemd-home"}
+-auth       sufficient                                   pam_systemd_home.so                                      {include if "with-systemd-home"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_first_pass
 auth        required                                     pam_faillock.so authfail                                 {include if "with-faillock"}
@@ -13,14 +13,14 @@ auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                            {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                          {include if "with-faillock"}
--account    sufficient                                   pam_systemd_home.so debug                              {include if "with-systemd-home"}
+-account    sufficient                                   pam_systemd_home.so                                      {include if "with-systemd-home"}
 account     required                                     pam_unix.so broken_shadow
 account     sufficient                                   pam_localuser.so
 account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_winbind.so {if "with-krb5":krb5_auth}
 account     required                                     pam_permit.so
 
--password   sufficient                                   pam_systemd_home.so debug                               {include if "with-systemd-home"}
+-password   sufficient                                   pam_systemd_home.so                                      {include if "with-systemd-home"}
 password    requisite                                    pam_pwquality.so local_users_only
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
 password    sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_authtok
@@ -29,7 +29,7 @@ password    required                                     pam_deny.so
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                  {include if "with-ecryptfs"}
--session    optional                                     pam_systemd_home.so  debug                              {include if "with-systemd-home"}
+-session    optional                                     pam_systemd_home.so                                     {include if "with-systemd-home"}
 -session    optional                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so                                 {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid

--- a/profiles/winbind/system-auth
+++ b/profiles/winbind/system-auth
@@ -5,6 +5,7 @@ auth        sufficient                                   pam_fprintd.so         
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
+-auth       sufficient                                   pam_systemd_home.so debug                              {include if "with-systemd-home"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_first_pass
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
@@ -13,12 +14,14 @@ auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
+-account    sufficient                                   pam_systemd_home.so debug                              {include if "with-systemd-home"}
 account     required                                     pam_unix.so broken_shadow
 account     sufficient                                   pam_localuser.so
 account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_winbind.so {if "with-krb5":krb5_auth}
 account     required                                     pam_permit.so
 
+-password   sufficient                                   pam_systemd_home.so debug                              {include if "with-systemd-home"}
 password    requisite                                    pam_pwquality.so local_users_only
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
 password    sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_authtok
@@ -27,6 +30,7 @@ password    required                                     pam_deny.so
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
+-session    optional                                     pam_systemd_home.so  debug                            {include if "with-systemd-home"}
 -session    optional                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid

--- a/profiles/winbind/system-auth
+++ b/profiles/winbind/system-auth
@@ -5,7 +5,7 @@ auth        sufficient                                   pam_fprintd.so         
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
--auth       sufficient                                   pam_systemd_home.so debug                              {include if "with-systemd-home"}
+-auth       sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-home"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_first_pass
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
@@ -14,14 +14,14 @@ auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
--account    sufficient                                   pam_systemd_home.so debug                              {include if "with-systemd-home"}
+-account    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-home"}
 account     required                                     pam_unix.so broken_shadow
 account     sufficient                                   pam_localuser.so
 account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_winbind.so {if "with-krb5":krb5_auth}
 account     required                                     pam_permit.so
 
--password   sufficient                                   pam_systemd_home.so debug                              {include if "with-systemd-home"}
+-password   sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-home"}
 password    requisite                                    pam_pwquality.so local_users_only
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
 password    sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_authtok
@@ -30,7 +30,7 @@ password    required                                     pam_deny.so
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
--session    optional                                     pam_systemd_home.so  debug                            {include if "with-systemd-home"}
+-session    optional                                     pam_systemd_home.so                                   {include if "with-systemd-home"}
 -session    optional                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid


### PR DESCRIPTION
pam_systemd_home ensures that home directories managed by systemd-homed.service(8) are automatically activated (mounted) on user login, and are deactivated (unmounted) when the last session of the user ends.

Resolves:
https://bugzilla.redhat.com/show_bug.cgi?id=1806949