### PR TITLE
profiles: add systemd to nsswitch shadow and gshadow

### DIFF
--- a/profiles/minimal/nsswitch.conf
+++ b/profiles/minimal/nsswitch.conf
@@ -1,7 +1,8 @@
 # In order of likelihood of use to accelerate lookup.
 passwd:     files {if "with-altfiles":altfiles }systemd
-shadow:     files
+shadow:     files systemd
 group:      files {if "with-altfiles":altfiles }systemd
+gshadow:    files systemd
 hosts:      files myhostname {if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] dns
 services:   files
 netgroup:   files

--- a/profiles/nis/nsswitch.conf
+++ b/profiles/nis/nsswitch.conf
@@ -1,7 +1,8 @@
 # In order of likelihood of use to accelerate lookup.
 passwd:     files {if "with-altfiles":altfiles }nis systemd
-shadow:     files nis
+shadow:     files nis systemd
 group:      files {if "with-altfiles":altfiles }nis systemd
+gshadow:    files nis systemd
 hosts:      files myhostname {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] nis dns
 services:   files nis
 netgroup:   files nis

--- a/profiles/sssd/nsswitch.conf
+++ b/profiles/sssd/nsswitch.conf
@@ -1,7 +1,8 @@
 # In order of likelihood of use to accelerate lookup.
 passwd:     {if "with-files-domain":sss }files {if "with-altfiles":altfiles }{if not "with-files-domain":sss }systemd
-shadow:     files
+shadow:     files systemd
 group:      {if "with-files-domain":sss }files {if "with-altfiles":altfiles }{if not "with-files-domain":sss }systemd
+gshadow:    files systemd
 hosts:      files myhostname {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] dns
 services:   files sss
 netgroup:   files sss

--- a/profiles/winbind/nsswitch.conf
+++ b/profiles/winbind/nsswitch.conf
@@ -1,7 +1,8 @@
 # In order of likelihood of use to accelerate lookup.
 passwd:     files {if "with-altfiles":altfiles }winbind systemd
-shadow:     files
+shadow:     files systemd
 group:      files {if "with-altfiles":altfiles }winbind systemd
+gshadow:    files systemd
 hosts:      files myhostname {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] dns
 services:   files
 netgroup:   files


### PR DESCRIPTION
nss_systemd also implements shadow and gshadow so it should be set
for these databases as well.