### PR TITLE
Fix installation of manpage

### DIFF
--- a/scripts/manpages-install.sh.in
+++ b/scripts/manpages-install.sh.in
@@ -35,22 +35,22 @@ MANDIR="@mandir@"
 manpages-find() {
     local PAGE="$1"
 
-    /usr/bin/find @abs_top_builddir@/src/man/translations \
+    find @abs_top_builddir@/src/man/translations \
          -type f -name "$PAGE" -printf '%d\t%p\n' | sort -nk1 | cut -f2-
 }
 
 # Install translated manual page.
 # Usage: manpages-install PAGE
 manpages-install() {
-    local PATH="$1"
-    local NAME=`/usr/bin/basename "$PATH"`
-    local LANG=`echo $PATH | /usr/bin/sed -E 's|.*/([^./]+)/[^/]+|\1|'`
-    local SECTION=`echo $PATH | /usr/bin/sed -E 's|.*\.(.)|\1|'`
+    local PATHNAME="$1"
+    local NAME=`basename "$PATHNAME"`
+    local LANG=`echo $PATHNAME | sed -E 's|.*/([^./]+)/[^/]+|\1|'`
+    local SECTION=`echo $PATHNAME | sed -E 's|.*\.(.)|\1|'`
     local DEST="$DESTDIR/$MANDIR/$LANG/man$SECTION"
 
-    echo "Installing $PATH to $DEST/$NAME"
-    /usr/bin/mkdir -p $DEST
-    /usr/bin/install -c -m 644 $PATH "$DEST/$NAME"
+    echo "Installing $PATHNAME to $DEST/$NAME"
+    mkdir -p $DEST
+    install -c -m 644 $PATHNAME "$DEST/$NAME"
 }
 
 for MANPAGE in $MANPAGES; do


### PR DESCRIPTION
Fix errors when required command (find, basename, sed, install) can be found somewhere else; don't using system enviroment variable PATH with brokes normal command invocations.