### PR TITLE
Change `system-auth` `auth sufficient` order

### DIFF
--- a/profiles/nis/password-auth
+++ b/profiles/nis/password-auth
@@ -1,7 +1,7 @@
 auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
 auth        required                                     pam_faillock.so preauth silent                           {include if "with-faillock"}
-auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
+auth        requisite                                    pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}

--- a/profiles/nis/password-auth
+++ b/profiles/nis/password-auth
@@ -1,8 +1,9 @@
 auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
 auth        required                                     pam_faillock.so preauth silent                           {include if "with-faillock"}
-auth        sufficient                                   pam_u2f.so cue                                           {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
+auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
+auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
 auth        sufficient                                   pam_systemd_home.so                                      {include if "with-systemd-homed"}
 auth        required                                     pam_faillock.so authfail                                 {include if "with-faillock"}

--- a/profiles/nis/system-auth
+++ b/profiles/nis/system-auth
@@ -1,7 +1,7 @@
 auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
-auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
+auth        requisite                                    pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}

--- a/profiles/nis/system-auth
+++ b/profiles/nis/system-auth
@@ -1,9 +1,9 @@
 auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
-auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
-auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
+auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
+auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
 auth        sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}

--- a/profiles/sssd/password-auth
+++ b/profiles/sssd/password-auth
@@ -2,8 +2,9 @@ auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
 auth        required                                     pam_deny.so # Smartcard authentication is required     {include if "with-smartcard-required"}
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
-auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
+auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
+auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        [default=1 ignore=ignore success=ok]         pam_localuser.so
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}

--- a/profiles/sssd/password-auth
+++ b/profiles/sssd/password-auth
@@ -2,7 +2,7 @@ auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
 auth        required                                     pam_deny.so # Smartcard authentication is required     {include if "with-smartcard-required"}
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
-auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
+auth        requisite                                    pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular

--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -4,7 +4,7 @@ auth        required                                     pam_faildelay.so delay=
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
 auth        [success=1 default=ignore]                   pam_succeed_if.so service notin login:gdm:xdm:kdm:kde:xscreensaver:gnome-screensaver:kscreensaver quiet use_uid {include if "with-smartcard-required"}
 auth        [success=done ignore=ignore default=die]     pam_sss.so require_cert_auth ignore_authinfo_unavail   {include if "with-smartcard-required"}
-auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
+auth        requisite                                    pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular

--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -4,9 +4,9 @@ auth        required                                     pam_faildelay.so delay=
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
 auth        [success=1 default=ignore]                   pam_succeed_if.so service notin login:gdm:xdm:kdm:kde:xscreensaver:gnome-screensaver:kscreensaver quiet use_uid {include if "with-smartcard-required"}
 auth        [success=done ignore=ignore default=die]     pam_sss.so require_cert_auth ignore_authinfo_unavail   {include if "with-smartcard-required"}
-auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
-auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
+auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
+auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        [default=1 ignore=ignore success=ok]         pam_localuser.so                                       {exclude if "with-smartcard"}
 auth        [default=2 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-smartcard"}

--- a/profiles/winbind/password-auth
+++ b/profiles/winbind/password-auth
@@ -1,7 +1,7 @@
 auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
 auth        required                                     pam_faillock.so preauth silent                           {include if "with-faillock"}
-auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
+auth        requisite                                    pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}

--- a/profiles/winbind/password-auth
+++ b/profiles/winbind/password-auth
@@ -1,8 +1,9 @@
 auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
 auth        required                                     pam_faillock.so preauth silent                           {include if "with-faillock"}
-auth        sufficient                                   pam_u2f.so cue                                           {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
+auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
+auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
 auth        sufficient                                   pam_systemd_home.so                                      {include if "with-systemd-homed"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular

--- a/profiles/winbind/system-auth
+++ b/profiles/winbind/system-auth
@@ -1,7 +1,7 @@
 auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
-auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
+auth        requisite                                    pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}

--- a/profiles/winbind/system-auth
+++ b/profiles/winbind/system-auth
@@ -1,9 +1,9 @@
 auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
-auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
-auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
+auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
+auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
 auth        sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular


### PR DESCRIPTION
When the user has set both a yubikey and a fingerprint sensor, the former fails quick when no suitable device is present, while the latter awaits the user input and retries.

A sensible order is then to try the yubikey first and then the fingerprint.

Note that it is ambiguous when the user has a setup of `with-pam-u2f-2fa` and `with-fingerprint`, i.e. does the user want:
- successfully login if fingerprint only is present
- require yubikey present, but can login either via fingerprint or password

I suspect that the latter was done even without the reordering of `auth required pam_u2f.so cue`, but I am not familiar enough to confirm this, or to know how can one configure it for the first scenario