### PR TITLE
Add `pam_krb5` as a fallback auth method for `sssd` profile.

### DIFF
--- a/profiles/sssd/README
+++ b/profiles/sssd/README
@@ -68,6 +68,9 @@ without-pam-u2f-nouserok::
     authentication configured will not be able to log in *INCLUDING* root.
     Make sure you are able to log in before losing root privileges.
 
+with-pam_krb5::
+    Enable fallback to pam_krb5 if other authentication methods fail.
+
 with-silent-lastlog::
     Do not produce pam_lastlog message during login.
 

--- a/profiles/sssd/REQUIREMENTS
+++ b/profiles/sssd/REQUIREMENTS
@@ -13,6 +13,8 @@ Make sure that SSSD service is configured and enabled. See SSSD documentation fo
                                                                                           {include if "with-pam-u2f-2fa"}
 - with-pam-u2f-2fa is selected, make sure that the pam u2f module is installed            {include if "with-pam-u2f-2fa"}
   - users can then configure keys using the pamu2fcfg tool                                {include if "with-pam-u2f-2fa"}
+                                                                                          {include if "with-pam_krb5"}
+- with-pam_krb5 is selected, make sure that the pam_krb5 package is installed             {include if "with-pam_krb5"}
                                                                                           {include if "with-mkhomedir"}
 - with-mkhomedir is selected, make sure pam_oddjob_mkhomedir module                       {include if "with-mkhomedir"}
   is present and oddjobd service is enabled and active                                    {include if "with-mkhomedir"}

--- a/profiles/sssd/password-auth
+++ b/profiles/sssd/password-auth
@@ -10,6 +10,7 @@ auth        sufficient                                   pam_unix.so {if not "wi
 auth        sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_sss.so forward_pass
+auth        sufficient                                   pam_krb5.so use_first_pass                             {include if "with-pam_krb5"}
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        optional                                     pam_gnome_keyring.so auto_start                        {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so
@@ -29,6 +30,7 @@ password    [default=1 ignore=ignore success=ok]         pam_localuser.so       
 password    requisite                                    pam_pwhistory.so use_authtok                           {include if "with-pwhistory"}
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
 password    sufficient                                   pam_sss.so use_authtok
+password    sufficient                                   pam_krb5.so use_authtok                                {include if "with-pam_krb5"}
 password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so revoke
@@ -41,3 +43,4 @@ session     [success=1 default=ignore]                   pam_succeed_if.so servi
 session     required                                     pam_unix.so
 session     optional                                     pam_sss.so
 session     optional                                     pam_gnome_keyring.so auto_start                        {include if "with-pam-gnome-keyring"}
+session     optional                                     pam_krb5.so                                            {include if "with-pam_krb5"}

--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -17,6 +17,7 @@ auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregul
 auth        sufficient                                   pam_sss_gss.so                                         {include if "with-gssapi"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_sss.so forward_pass
+auth        sufficient                                   pam_krb5.so use_first_pass                             {include if "with-pam_krb5"}
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so
@@ -36,6 +37,7 @@ password    [default=1 ignore=ignore success=ok]         pam_localuser.so       
 password    requisite                                    pam_pwhistory.so use_authtok                           {include if "with-pwhistory"}
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
 password    sufficient                                   pam_sss.so use_authtok
+password    sufficient                                   pam_krb5.so use_authtok                                {include if "with-pam_krb5"}
 password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so revoke
@@ -48,3 +50,4 @@ session     [success=1 default=ignore]                   pam_succeed_if.so servi
 session     required                                     pam_unix.so
 session     optional                                     pam_sss.so
 session     optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}
+session     optional                                     pam_krb5.so                                            {include if "with-pam_krb5"}


### PR DESCRIPTION
I'm engaged in long term conversation with the `sssd` folks about authentication features of `pam_krb5` not present in `sssd`.

I maintain `pam_krb5` in Fedora and EPEL.

Having a simple switch to enable this fallback would be helpful.