### PR TITLE
profiles: do not try to change password via sssd for local users

### DIFF
--- a/profiles/sssd/password-auth
+++ b/profiles/sssd/password-auth
@@ -28,6 +28,7 @@ password    requisite                                    pam_pwquality.so local_
 password    [default=1 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-pwhistory"}
 password    requisite                                    pam_pwhistory.so use_authtok                           {include if "with-pwhistory"}
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
+password    [success=1 default=ignore]                   pam_localuser.so
 password    sufficient                                   pam_sss.so use_authtok
 password    required                                     pam_deny.so
 

--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -35,6 +35,7 @@ password    requisite                                    pam_pwquality.so local_
 password    [default=1 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-pwhistory"}
 password    requisite                                    pam_pwhistory.so use_authtok                           {include if "with-pwhistory"}
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
+password    [success=1 default=ignore]                   pam_localuser.so
 password    sufficient                                   pam_sss.so use_authtok
 password    required                                     pam_deny.so
 


### PR DESCRIPTION
Steps to reproduce:
1. Create local user and set passsword
2. Log in as the local user
3. Run passwd and provide wrong password as "Current password"

"Current password" prompt should be printed only once.

Resolves: https://github.com/authselect/authselect/issues/338