### PR TITLE
Add switch to permit including external config

### DIFF
--- a/profiles/minimal/README
+++ b/profiles/minimal/README
@@ -47,6 +47,11 @@ with-mdns6::
 with-systemd-homed::
     If set, pam_systemd_homed is enabled for all pam operations.
 
+with-custom-pam-include::
+    If set pam will include a file called `custom-authselect`.
+    You are responsible to ensure the file exists and has safe
+    values for your environment.
+
 without-nullok::
     Do not add nullok parameter to pam_unix.
 

--- a/profiles/minimal/REQUIREMENTS
+++ b/profiles/minimal/REQUIREMENTS
@@ -6,3 +6,5 @@
                                                                                           {include if "with-systemd-homed"}
 - with-systemd-homed is selected, make sure that the system-homed service is enabled      {include if "with-systemd-homed"}
   - systemctl enable --now systemd-homed.service                                          {include if "with-systemd-homed"}
+                                                                                          {include if "with-custom-pam-include"}
+- with-custom-pam-include is selected, make sure custom-authselect file is present        {include if "with-custom-pam-include"}

--- a/profiles/minimal/password-auth
+++ b/profiles/minimal/password-auth
@@ -4,18 +4,21 @@ auth        required                                     pam_faillock.so preauth
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
 auth        sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
+auth        include                                      custom-authselect                                      {include if "with-custom-pam-include"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
 account     sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 account     required                                     pam_unix.so
+account     include                                      custom-authselect                                      {include if "with-custom-pam-include"}
 
 password    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 password    requisite                                    pam_pwquality.so
 password    [default=1 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-pwhistory"}
 password    requisite                                    pam_pwhistory.so use_authtok                           {include if "with-pwhistory"}
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
+password    include                                      custom-authselect                                      {include if "with-custom-pam-include"}
 password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so revoke
@@ -26,3 +29,4 @@ session     optional                                     pam_systemd_home.so    
 session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
+session     include                                      custom-authselect                                     {include if "with-custom-pam-include"}

--- a/profiles/minimal/system-auth
+++ b/profiles/minimal/system-auth
@@ -4,18 +4,21 @@ auth        required                                     pam_faillock.so preauth
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
 auth        sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
+auth        include                                      custom-authselect                                      {include if "with-custom-pam-include"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
 account     sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 account     required                                     pam_unix.so
+account     include                                      custom-authselect                                      {include if "with-custom-pam-include"}
 
 password    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 password    requisite                                    pam_pwquality.so
 password    [default=1 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-pwhistory"}
 password    requisite                                    pam_pwhistory.so use_authtok                           {include if "with-pwhistory"}
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
+password    include                                      custom-authselect                                      {include if "with-custom-pam-include"}
 password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so revoke
@@ -25,4 +28,5 @@ session     optional                                     pam_systemd_home.so    
 -session    optional                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
+session     include                                      custom-authselect                                     {include if "with-custom-pam-include"}
 session     required                                     pam_unix.so

--- a/profiles/nis/README
+++ b/profiles/nis/README
@@ -68,6 +68,11 @@ with-mdns6::
 with-systemd-homed::
     If set, pam_systemd_homed is enabled for all pam operations.
 
+with-custom-pam-include::
+    If set pam will include a file called `custom-authselect`.
+    You are responsible to ensure the file exists and has safe
+    values for your environment.
+
 without-nullok::
     Do not add nullok parameter to pam_unix.
 

--- a/profiles/nis/REQUIREMENTS
+++ b/profiles/nis/REQUIREMENTS
@@ -19,3 +19,5 @@ Make sure that NIS service is configured and enabled. See NIS documentation for 
                                                                                           {include if "with-systemd-homed"}
 - with-systemd-homed is selected, make sure that the system-homed service is enabled      {include if "with-systemd-homed"}
   - systemctl enable --now systemd-homed.service                                          {include if "with-systemd-homed"}
+                                                                                          {include if "with-custom-pam-include"}
+- with-custom-pam-include is selected, make sure custom-authselect file is present        {include if "with-custom-pam-include"}

--- a/profiles/nis/password-auth
+++ b/profiles/nis/password-auth
@@ -7,18 +7,21 @@ auth        sufficient                                   pam_unix.so {if not "wi
 auth        sufficient                                   pam_systemd_home.so                                      {include if "with-systemd-homed"}
 auth        required                                     pam_faillock.so authfail                                 {include if "with-faillock"}
 auth        optional                                     pam_gnome_keyring.so only_if=login auto_start            {include if "with-pam-gnome-keyring"}
+auth        include                                      custom-authselect                                        {include if "with-custom-pam-include"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                            {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                          {include if "with-faillock"}
 account     sufficient                                   pam_systemd_home.so                                      {include if "with-systemd-homed"}
 account     required                                     pam_unix.so broken_shadow
+account     include                                      custom-authselect                                        {include if "with-custom-pam-include"}
 
 password    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 password    requisite                                    pam_pwquality.so {if not "with-nispwquality":local_users_only}
 password    [default=1 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-pwhistory"}
 password    requisite                                    pam_pwhistory.so use_authtok                           {include if "with-pwhistory"}
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok nis
+password    include                                      custom-authselect                                      {include if "with-custom-pam-include"}
 password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so revoke
@@ -30,3 +33,4 @@ session     optional                                     pam_oddjob_mkhomedir.so
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
 session     optional                                     pam_gnome_keyring.so only_if=login auto_start           {include if "with-pam-gnome-keyring"}
+session     include                                      custom-authselect                                       {include if "with-custom-pam-include"}

--- a/profiles/nis/system-auth
+++ b/profiles/nis/system-auth
@@ -8,18 +8,21 @@ auth        sufficient                                   pam_unix.so {if not "wi
 auth        sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}
+auth        include                                      custom-authselect                                      {include if "with-custom-pam-include"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
 account     sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 account     required                                     pam_unix.so broken_shadow
+account     include                                      custom-authselect                                      {include if "with-custom-pam-include"}
 
 password    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 password    requisite                                    pam_pwquality.so {if not "with-nispwquality":local_users_only}
 password    [default=1 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-pwhistory"}
 password    requisite                                    pam_pwhistory.so use_authtok                           {include if "with-pwhistory"}
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok nis
+password    include                                      custom-authselect                                      {include if "with-custom-pam-include"}
 password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so revoke
@@ -31,3 +34,4 @@ session     optional                                     pam_oddjob_mkhomedir.so
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
 session     optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}
+session     include                                      custom-authselect                                      {include if "with-custom-pam-include"}

--- a/profiles/sssd/README
+++ b/profiles/sssd/README
@@ -114,6 +114,11 @@ with-subid::
 with-systemd-homed::
     If set, pam_systemd_homed is enabled for all pam operations.
 
+with-custom-pam-include::
+    If set pam will include a file called `custom-authselect`.
+    You are responsible to ensure the file exists and has safe
+    values for your environment.
+
 without-nullok::
     Do not add nullok parameter to pam_unix.
 

--- a/profiles/sssd/REQUIREMENTS
+++ b/profiles/sssd/REQUIREMENTS
@@ -30,3 +30,5 @@ Make sure that SSSD service is configured and enabled. See SSSD documentation fo
                                                                                           {include if "with-systemd-homed"}
 - with-systemd-homed is selected, make sure that the system-homed service is enabled      {include if "with-systemd-homed"}
   - systemctl enable --now systemd-homed.service                                          {include if "with-systemd-homed"}
+                                                                                          {include if "with-custom-pam-include"}
+- with-custom-pam-include is selected, make sure custom-authselect file is present        {include if "with-custom-pam-include"}

--- a/profiles/sssd/password-auth
+++ b/profiles/sssd/password-auth
@@ -12,6 +12,7 @@ auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregul
 auth        sufficient                                   pam_sss.so forward_pass
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        optional                                     pam_gnome_keyring.so auto_start                        {include if "with-pam-gnome-keyring"}
+auth        include                                      custom-authselect                                      {include if "with-custom-pam-include"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
@@ -22,6 +23,7 @@ account     sufficient                                   pam_localuser.so       
 account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 account     required                                     pam_permit.so
+account     include                                      custom-authselect                                      {include if "with-custom-pam-include"}
 
 password    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 password    requisite                                    pam_pwquality.so local_users_only
@@ -30,6 +32,7 @@ password    requisite                                    pam_pwhistory.so use_au
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
 password    [success=1 default=ignore]                   pam_localuser.so
 password    sufficient                                   pam_sss.so use_authtok
+password    include                                      custom-authselect                                      {include if "with-custom-pam-include"}
 password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so revoke
@@ -42,3 +45,4 @@ session     [success=1 default=ignore]                   pam_succeed_if.so servi
 session     required                                     pam_unix.so
 session     optional                                     pam_sss.so
 session     optional                                     pam_gnome_keyring.so auto_start                        {include if "with-pam-gnome-keyring"}
+session     include                                      custom-authselect                                      {include if "with-custom-pam-include"}

--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -19,6 +19,7 @@ auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregul
 auth        sufficient                                   pam_sss.so forward_pass
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}
+auth        include                                      custom-authselect                                      {include if "with-custom-pam-include"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
@@ -29,6 +30,7 @@ account     sufficient                                   pam_localuser.so       
 account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 account     required                                     pam_permit.so
+account     include                                      custom-authselect                                      {include if "with-custom-pam-include"}
 
 password    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 password    requisite                                    pam_pwquality.so local_users_only
@@ -37,6 +39,7 @@ password    requisite                                    pam_pwhistory.so use_au
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
 password    [success=1 default=ignore]                   pam_localuser.so
 password    sufficient                                   pam_sss.so use_authtok
+password    include                                      custom-authselect                                      {include if "with-custom-pam-include"}
 password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so revoke
@@ -49,3 +52,4 @@ session     [success=1 default=ignore]                   pam_succeed_if.so servi
 session     required                                     pam_unix.so
 session     optional                                     pam_sss.so
 session     optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}
+session     include                                      custom-authselect                                      {include if "with-custom-pam-include"}

--- a/profiles/winbind/README
+++ b/profiles/winbind/README
@@ -78,6 +78,11 @@ with-mdns6::
 with-systemd-homed::
     If set, pam_systemd_homed is enabled for all pam operations.
 
+with-custom-pam-include::
+    If set pam will include a file called `custom-authselect`.
+    You are responsible to ensure the file exists and has safe
+    values for your environment.
+
 without-nullok::
     Do not add nullok parameter to pam_unix.
 

--- a/profiles/winbind/REQUIREMENTS
+++ b/profiles/winbind/REQUIREMENTS
@@ -19,3 +19,5 @@ Make sure that winbind service is configured and enabled. See winbind documentat
                                                                                           {include if "with-systemd-homed"}
 - with-systemd-homed is selected, make sure that the system-homed service is enabled      {include if "with-systemd-homed"}
   - systemctl enable --now systemd-homed.service                                          {include if "with-systemd-homed"}
+                                                                                          {include if "with-custom-pam-include"}
+- with-custom-pam-include is selected, make sure custom-authselect file is present        {include if "with-custom-pam-include"}

--- a/profiles/winbind/password-auth
+++ b/profiles/winbind/password-auth
@@ -9,6 +9,7 @@ auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregul
 auth        sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_first_pass
 auth        required                                     pam_faillock.so authfail                                 {include if "with-faillock"}
 auth        optional                                     pam_gnome_keyring.so only_if=login auto_start            {include if "with-pam-gnome-keyring"}
+auth        include                                      custom-authselect                                        {include if "with-custom-pam-include"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                            {include if "with-pamaccess"}
@@ -19,6 +20,7 @@ account     sufficient                                   pam_localuser.so
 account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_winbind.so {if "with-krb5":krb5_auth}
 account     required                                     pam_permit.so
+account     include                                      custom-authselect                                        {include if "with-custom-pam-include"}
 
 password    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 password    requisite                                    pam_pwquality.so local_users_only
@@ -26,6 +28,7 @@ password    [default=1 ignore=ignore success=ok]         pam_localuser.so       
 password    requisite                                    pam_pwhistory.so use_authtok                           {include if "with-pwhistory"}
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
 password    sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_authtok
+password    include                                      custom-authselect                                      {include if "with-custom-pam-include"}
 password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so revoke
@@ -38,3 +41,4 @@ session     [success=1 default=ignore]                   pam_succeed_if.so servi
 session     required                                     pam_unix.so
 session     optional                                     pam_winbind.so {if "with-krb5":krb5_auth}
 session     optional                                     pam_gnome_keyring.so only_if=login auto_start           {include if "with-pam-gnome-keyring"}
+session     include                                      custom-authselect                                       {include if "with-custom-pam-include"}

--- a/profiles/winbind/system-auth
+++ b/profiles/winbind/system-auth
@@ -10,6 +10,7 @@ auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregul
 auth        sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_first_pass
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}
+auth        include                                      custom-authselect                                      {include if "with-custom-pam-include"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
@@ -20,6 +21,7 @@ account     sufficient                                   pam_localuser.so
 account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_winbind.so {if "with-krb5":krb5_auth}
 account     required                                     pam_permit.so
+account     include                                      custom-authselect                                      {include if "with-custom-pam-include"}
 
 password    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 password    requisite                                    pam_pwquality.so local_users_only
@@ -27,6 +29,7 @@ password    [default=1 ignore=ignore success=ok]         pam_localuser.so       
 password    requisite                                    pam_pwhistory.so use_authtok                           {include if "with-pwhistory"}
 password    sufficient                                   pam_unix.so yescrypt shadow {if not "without-nullok":nullok} use_authtok
 password    sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_authtok
+password    include                                      custom-authselect                                      {include if "with-custom-pam-include"}
 password    required                                     pam_deny.so
 
 session     optional                                     pam_keyinit.so revoke
@@ -39,3 +42,4 @@ session     [success=1 default=ignore]                   pam_succeed_if.so servi
 session     required                                     pam_unix.so
 session     optional                                     pam_winbind.so {if "with-krb5":krb5_auth}
 session     optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}
+session     include                                      custom-authselect                                      {include if "with-custom-pam-include"}


### PR DESCRIPTION
This adds a place where I can trivially seed an external config file for pam.

Example usage, since the pam_oathtool patch didn't get merged, this will provide a place I can drop in my config without needing to fork the entire profile.