### PR TITLE
selinux: correct error message

### DIFF
--- a/src/lib/util/selinux.c
+++ b/src/lib/util/selinux.c
@@ -43,7 +43,7 @@ selinux_get_default_context(const char *path,
     handle = selabel_open(SELABEL_CTX_FILE, NULL, 0);
     if (handle == NULL) {
         ret = errno;
-        ERROR("Unable to create selabel context [%d]: %s", ret, strerror(ret));
+        ERROR("Unable to create selabel handle [%d]: %s", ret, strerror(ret));
         return ret;
     }
 


### PR DESCRIPTION
So it does not get confused with selinux context.