### PR TITLE
authselect: add fallback config file in /usr/ if the main one in /etc…

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -29,6 +29,7 @@ EXTRA_DIST = \
 
 # Create authselect directories
 authselect_config_dir=@AUTHSELECT_CONFIG_DIR@
+authselect_config_fallback_dir=@AUTHSELECT_CONFIG_FALLBACK_DIR@
 authselect_vendor_dir=@AUTHSELECT_VENDOR_DIR@
 authselect_custom_dir=@AUTHSELECT_CUSTOM_DIR@
 authselect_dconf_dir=@AUTHSELECT_DCONF_DIR@
@@ -37,6 +38,7 @@ authselect_backup_dir=@AUTHSELECT_BACKUP_DIR@
 
 install-exec-hook:
 	$(MKDIR_P) $(DESTDIR)$/$(authselect_config_dir)
+	$(MKDIR_P) $(DESTDIR)$/$(authselect_config_fallback_dir)
 	$(MKDIR_P) $(DESTDIR)$/$(authselect_vendor_dir)
 	$(MKDIR_P) $(DESTDIR)$/$(authselect_custom_dir)
 	$(MKDIR_P) $(DESTDIR)$/$(authselect_dconf_dir)

--- a/src/conf_macros.m4
+++ b/src/conf_macros.m4
@@ -22,6 +22,10 @@ CONFIGURABLE_VALUE(config-dir, config_dir, AUTHSELECT_CONFIG_DIR, DIR,
                    [Path to the directory where authselect stores its configuration],
                    $sysconfdir/authselect)
 
+CONFIGURABLE_VALUE(config-fallback-dir, config_fallback_dir, AUTHSELECT_CONFIG_FALLBACK_DIR, DIR,
+                   [Path to the directory where authselect looks for fallback configuration],
+                   $datarootdir/authselect)
+
 CONFIGURABLE_VALUE(profile-dir, profile_dir, AUTHSELECT_PROFILE_DIR, DIR,
                    [Path to the directory where are stored authselect default profiles],
                    $datarootdir/authselect/default)

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -34,6 +34,7 @@ lib_LTLIBRARIES = \
     $(NULL)
 
 authselect_config_dir=@AUTHSELECT_CONFIG_DIR@
+authselect_config_fallback_dir=@AUTHSELECT_CONFIG_FALLBACK_DIR@
 authselect_profile_dir=@AUTHSELECT_PROFILE_DIR@
 authselect_vendor_dir=@AUTHSELECT_VENDOR_DIR@
 authselect_custom_dir=@AUTHSELECT_CUSTOM_DIR@
@@ -74,6 +75,7 @@ libauthselect_la_LIBADD = \
 libauthselect_la_CFLAGS = \
     $(AM_CFLAGS) \
     -DAUTHSELECT_CONFIG_DIR=\"$(authselect_config_dir)\" \
+    -DAUTHSELECT_CONFIG_FALLBACK_DIR=\"$(authselect_config_fallback_dir)\" \
     -DAUTHSELECT_PROFILE_DIR=\"$(authselect_profile_dir)\" \
     -DAUTHSELECT_VENDOR_DIR=\"$(authselect_vendor_dir)\" \
     -DAUTHSELECT_CUSTOM_DIR=\"$(authselect_custom_dir)\" \

--- a/src/lib/files/config.c
+++ b/src/lib/files/config.c
@@ -70,6 +70,11 @@ authselect_config_read(char **_profile_id,
     ret = textfile_read(PATH_CONFIG_FILE,
                         AUTHSELECT_FILE_SIZE_LIMIT,
                         &content);
+    if (ret == ENOENT) {
+        ret = textfile_read(PATH_CONFIG_FALLBACK_FILE,
+                            AUTHSELECT_FILE_SIZE_LIMIT,
+                            &content);
+    }
     if (ret != EOK) {
         return ret;
     }
@@ -228,6 +233,9 @@ authselect_config_validate_missing()
     int i;
 
     ret = file_exists(PATH_CONFIG_FILE);
+    if (ret == ENOENT) {
+        ret = file_exists(PATH_CONFIG_FALLBACK_FILE);
+    }
     if (ret != ENOENT) {
         return false;
     }

--- a/src/lib/paths.h
+++ b/src/lib/paths.h
@@ -26,6 +26,7 @@
 /* Authselect configuration file. */
 #define FILE_CONFIG      "authselect.conf"
 #define PATH_CONFIG_FILE AUTHSELECT_CONFIG_DIR "/" FILE_CONFIG
+#define PATH_CONFIG_FALLBACK_FILE AUTHSELECT_CONFIG_FALLBACK_DIR "/" FILE_CONFIG
 
 /* UID and GID of files owned by authselect. -1 means do not check. */
 #define AUTHSELECT_UID -1


### PR DESCRIPTION
…/ doesn't exist

This implements one of the two ideas from https://github.com/authselect/authselect/issues/355

The mechanism is simple: when trying to read the configuration file and /etc/authselect/authselect.conf does not exist, we'll look for /usr/share/authselect/authselect.conf as a fallback configuration file. When writing/modifying we do not bother with the fallback file however, as any changes should only hit /etc/, never /usr/.

This useful in scenarios where /usr/ is immutable and /etc/ initially comes up empty: running authconfig like that will consume the fallback configuration, but then write out the local configuration in /etc/.

See: #355