### PR TITLE
authselect: automatically run authselect apply-changes on first boot

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,6 +6,7 @@ SUBDIRS= \
     src/lib \
     src/cli \
     src/tests \
+    systemd \
     $(NULL)
 
 if HAVE_MANPAGES

--- a/configure.ac
+++ b/configure.ac
@@ -57,7 +57,8 @@ AC_CONFIG_FILES([Makefile
                  src/lib/Makefile
                  src/lib/authselect.pc
                  src/man/Makefile
-                 src/tests/Makefile])
+                 src/tests/Makefile
+                 systemd/Makefile])
 
 AC_CONFIG_FILES([scripts/manpages-build.sh],
                 [chmod +x scripts/manpages-build.sh])

--- a/rpm/authselect.spec.in
+++ b/rpm/authselect.spec.in
@@ -252,6 +252,8 @@ find $RPM_BUILD_ROOT -name "*.a" -exec %__rm -f {} \;
 %{_mandir}/man8/authselect.8*
 %{_mandir}/man7/authselect-migration.7*
 %{_sysconfdir}/bash_completion.d/authselect-completion.sh
+%{_prefix}/lib/systemd/system/authselect.service
+%{_prefix}/lib/systemd/system/sysinit.target.wants/authselect.service
 
 %global forcefile %{_localstatedir}/lib/rpm-state/%{name}.force
 

--- a/src/conf_macros.m4
+++ b/src/conf_macros.m4
@@ -66,6 +66,10 @@ CONFIGURABLE_VALUE(completion-dir, completion_dir, BASH_COMPLETION_DIR, DIR,
                    [Path to the directory where bash completion script should be stored],
                    $sysconfdir/bash_completion.d)
 
+CONFIGURABLE_VALUE(systemdunit-dir, systemdunit_dir, SYSTEMD_UNIT_DIR, DIR,
+                   [Directory where to drop systemd system units in],
+                   $prefix/lib/systemd/system)
+
 AC_ARG_ENABLE(
     [debug-template-regex],
     AS_HELP_STRING(

--- a/systemd/Makefile.am
+++ b/systemd/Makefile.am
@@ -1,0 +1,10 @@
+systemdunitdir=@SYSTEMD_UNIT_DIR@
+
+dist_systemdunit_DATA = \
+	authselect.service \
+	$(NULL)
+
+# Hook this into sysinit.target by default
+install-exec-hook:
+	$(MKDIR_P) $(DESTDIR)/$(systemdunitdir)/sysinit.target.wants
+	$(LN_S) -f ../authselect.service $(DESTDIR)/$(systemdunitdir)/sysinit.target.wants/authselect.service

--- a/systemd/authselect.service
+++ b/systemd/authselect.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Apply Authselect Configuration
+Documentation=man:authselect(8)
+ConditionFirstBoot=yes
+ConditionPathIsReadWrite=/etc
+DefaultDependencies=no
+After=systemd-remount-fs.service
+Wants=first-boot-complete.target
+Before=first-boot-complete.target sysinit.target
+Conflicts=shutdown.target
+Before=shutdown.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=authselect apply-changes


### PR DESCRIPTION
This installs an authselect.service file that is pulled in by sysinit.target and automatically runs "authselect apply-changes" on first boot (i.e. when /etc/ is unpopulated), and applies any available configuration.

Due to the ConditionFirstBoot= and ConditionPathIsReadWrite=/etc this has zero effect on systems which do not come up in a first boot mode, or where /etc/ is immutable.

See: #355