### PR TITLE
profiles: merge groups records with [SUCCESS=merge]

### DIFF
--- a/profiles/local/nsswitch.conf
+++ b/profiles/local/nsswitch.conf
@@ -1,7 +1,7 @@
 # In order of likelihood of use to accelerate lookup.
 passwd:     files {if "with-altfiles":altfiles }systemd
 shadow:     files
-group:      files {if "with-altfiles":altfiles }systemd
+group:      files [SUCCESS=merge] {if "with-altfiles":altfiles [SUCCESS=merge] }systemd
 hosts:      files myhostname {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] dns
 services:   files
 netgroup:   files

--- a/profiles/nis/nsswitch.conf
+++ b/profiles/nis/nsswitch.conf
@@ -1,7 +1,7 @@
 # In order of likelihood of use to accelerate lookup.
 passwd:     files {if "with-altfiles":altfiles }nis systemd
 shadow:     files nis
-group:      files {if "with-altfiles":altfiles }nis systemd
+group:      files [SUCCESS=merge] {if "with-altfiles":altfiles [SUCCESS=merge] }nis [SUCCESS=merge] systemd
 hosts:      files myhostname {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] nis dns
 services:   files nis
 netgroup:   files nis

--- a/profiles/sssd/nsswitch.conf
+++ b/profiles/sssd/nsswitch.conf
@@ -1,7 +1,7 @@
 # In order of likelihood of use to accelerate lookup.
 passwd:     {if "with-tlog":sss }files {if "with-altfiles":altfiles }{if not "with-tlog":sss }systemd
 shadow:     files
-group:      {if "with-tlog":sss }files {if "with-altfiles":altfiles }{if not "with-tlog":sss }systemd
+group:      {if "with-tlog":sss [SUCCESS=merge] }files [SUCCESS=merge] {if "with-altfiles":altfiles [SUCCESS=merge] }{if not "with-tlog":sss [SUCCESS=merge] }systemd
 hosts:      files myhostname {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] dns
 services:   files sss
 netgroup:   files sss

--- a/profiles/winbind/nsswitch.conf
+++ b/profiles/winbind/nsswitch.conf
@@ -1,7 +1,7 @@
 # In order of likelihood of use to accelerate lookup.
 passwd:     files {if "with-altfiles":altfiles }winbind systemd
 shadow:     files
-group:      files {if "with-altfiles":altfiles }winbind systemd
+group:      files [SUCCESS=merge] {if "with-altfiles":altfiles [SUCCESS=merge] }winbind [SUCCESS=merge] systemd
 hosts:      files myhostname {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] dns
 services:   files
 netgroup:   files

--- a/rpm/authselect.spec.in
+++ b/rpm/authselect.spec.in
@@ -223,7 +223,7 @@ exit 0
 if test -e /run/ostree-booted; then
     for PROFILE in `ls %{_datadir}/authselect/default`; do
         %{_bindir}/authselect create-profile $PROFILE --vendor --base-on $PROFILE --symlink-pam --symlink-dconf --symlink=REQUIREMENTS --symlink=README &> /dev/null
-        %__sed -ie 's/{if "with-altfiles":altfiles }/altfiles /g' %{_datadir}/authselect/vendor/$PROFILE/nsswitch.conf &> /dev/null
+        %__sed -ie 's/{if "with-altfiles":altfiles \[SUCCESS=merge\] }/altfiles [SUCCESS=merge] /g' %{_datadir}/authselect/vendor/$PROFILE/nsswitch.conf &> /dev/null
     done
 fi
 


### PR DESCRIPTION
Services such as systemd-homed would like to advertise users which are part of system groups, such as "wheel". That only works if glibc's [SUCCESS=merge] feature is used in nsswitch.conf, so that group records from multiple sources are merged.

This is documented here:

https://www.freedesktop.org/software/systemd/man/latest/nss-systemd.html#Configuration%20in%20/etc/nsswitch.conf

This hence adds [SUCCESS=merge] expressions to all NSS modules listed in the "groups" lines.