### PR TITLE
sssd: reintroduce with-files-access-provider

### DIFF
--- a/profiles/sssd/README
+++ b/profiles/sssd/README
@@ -89,6 +89,16 @@ with-mdns4::
 with-mdns6::
     Enable multicast DNS over IPv6.
 
+with-files-access-provider:: If set, account management for local users is
+    handled also by pam_sss. This can be used to support SSSD's proxy domain
+    that is configured to serve users from local files but provide
+    authentication and access management (.k5login file) via Kerberos.
+
+    *WARNING:* SSSD access check will become mandatory for local users and
+    if SSSD is stopped then local users will not be able to log in. Only
+    system accounts (as defined by pam_usertype, including root) will be
+    able to log in.
+
 with-gssapi::
     If set, pam_sss_gss module is enabled to perform user authentication over
     GSSAPI.

--- a/profiles/sssd/fingerprint-auth
+++ b/profiles/sssd/fingerprint-auth
@@ -11,7 +11,7 @@ auth        required                                     pam_deny.so
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
 account     required                                     pam_unix.so
-account     sufficient                                   pam_localuser.so
+account     sufficient                                   pam_localuser.so                                       {exclude if "with-files-access-provider"}
 account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 account     required                                     pam_permit.so

--- a/profiles/sssd/password-auth
+++ b/profiles/sssd/password-auth
@@ -18,7 +18,7 @@ account     required                                     pam_access.so          
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
 account     sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 account     required                                     pam_unix.so
-account     sufficient                                   pam_localuser.so
+account     sufficient                                   pam_localuser.so                                       {exclude if "with-files-access-provider"}
 account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 account     required                                     pam_permit.so

--- a/profiles/sssd/smartcard-auth
+++ b/profiles/sssd/smartcard-auth
@@ -11,7 +11,7 @@ auth        required                                     pam_deny.so
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
 account     required                                     pam_unix.so
-account     sufficient                                   pam_localuser.so
+account     sufficient                                   pam_localuser.so                                       {exclude if "with-files-access-provider"}
 account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 account     required                                     pam_permit.so

--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -25,7 +25,7 @@ account     required                                     pam_access.so          
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
 account     sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 account     required                                     pam_unix.so
-account     sufficient                                   pam_localuser.so
+account     sufficient                                   pam_localuser.so                                       {exclude if "with-files-access-provider"}
 account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 account     required                                     pam_permit.so


### PR DESCRIPTION
This is still needed to support .k5login file with proxy domain. For
example:

```
[domain/proxy]
id_provider = proxy
proxy_lib_name = files
access_provider = krb5
auth_provider = krb5
krb5_server = kdc.test
krb5_realm = TEST
```