### PR TITLE
profiles: put myhostname before dns

### DIFF
--- a/profiles/local/nsswitch.conf
+++ b/profiles/local/nsswitch.conf
@@ -2,7 +2,7 @@
 passwd:     files {if "with-altfiles":altfiles }systemd
 shadow:     files
 group:      files [SUCCESS=merge] {if "with-altfiles":altfiles [SUCCESS=merge] }systemd
-hosts:      files myhostname {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] dns
+hosts:      files {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] myhostname dns
 services:   files
 netgroup:   files
 automount:  files

--- a/profiles/nis/nsswitch.conf
+++ b/profiles/nis/nsswitch.conf
@@ -2,7 +2,7 @@
 passwd:     files {if "with-altfiles":altfiles }nis systemd
 shadow:     files nis
 group:      files [SUCCESS=merge] {if "with-altfiles":altfiles [SUCCESS=merge] }nis [SUCCESS=merge] systemd
-hosts:      files myhostname {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] nis dns
+hosts:      files {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] nis myhostname dns
 services:   files nis
 netgroup:   files nis
 automount:  files nis

--- a/profiles/sssd/nsswitch.conf
+++ b/profiles/sssd/nsswitch.conf
@@ -2,7 +2,7 @@
 passwd:     {if "with-tlog":sss }files {if "with-altfiles":altfiles }{if not "with-tlog":sss }systemd
 shadow:     files
 group:      {if "with-tlog":sss [SUCCESS=merge] }files [SUCCESS=merge] {if "with-altfiles":altfiles [SUCCESS=merge] }{if not "with-tlog":sss [SUCCESS=merge] }systemd
-hosts:      files myhostname {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] dns
+hosts:      files {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] myhostname dns
 services:   files sss
 netgroup:   files sss
 sudoers:    files sss {include if "with-sudo"}

--- a/profiles/winbind/nsswitch.conf
+++ b/profiles/winbind/nsswitch.conf
@@ -2,7 +2,7 @@
 passwd:     files {if "with-altfiles":altfiles }winbind systemd
 shadow:     files
 group:      files [SUCCESS=merge] {if "with-altfiles":altfiles [SUCCESS=merge] }winbind [SUCCESS=merge] systemd
-hosts:      files myhostname {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] dns
+hosts:      files {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] myhostname dns
 services:   files
 netgroup:   files
 automount:  files


### PR DESCRIPTION
To allow `hostname --fqdn` to work correctly. Putting myhostname early
prevents lookup of canonical hostname if only shortname is provided.

myhostname has been moved back and forth several times, it looks
like this place is now functional and works as expected.

See: https://bugzilla.redhat.com/show_bug.cgi?id=2257197#c11