### PR TITLE
spec: strengthen altfiles sed invocation

### DIFF
--- a/rpm/authselect.spec.in
+++ b/rpm/authselect.spec.in
@@ -212,7 +212,7 @@ fi
 if test -e /run/ostree-booted; then
     for PROFILE in `ls %{_datadir}/authselect/default`; do
         %{_bindir}/authselect create-profile $PROFILE --vendor --base-on $PROFILE --symlink-pam --symlink-dconf --symlink=REQUIREMENTS --symlink=README &> /dev/null
-        %__sed -ie 's/{if "with-altfiles":altfiles \[SUCCESS=merge\] }/altfiles [SUCCESS=merge] /g' %{_datadir}/authselect/vendor/$PROFILE/nsswitch.conf &> /dev/null
+        %__sed -i -e 's/{if "with-altfiles":\([^}]\+\)}/\1/g' %{_datadir}/authselect/vendor/$PROFILE/nsswitch.conf &> /dev/null
     done
 fi
 


### PR DESCRIPTION
The regex that was given matched the `group` line but not the `passwd` line (which doesn't have that `[SUCCESS=merge]` bit).

Generalize the regex instead so that we just take whatever the contents of the conditional was and put it in there.

Fixes: https://github.com/coreos/fedora-coreos-tracker/issues/1680
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2266344

(Upstreamed from https://src.fedoraproject.org/rpms/authselect/pull-request/22)