### PR TITLE
Add Packit configuration

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,31 @@
+---
+upstream_project_url: https://github.com/authselect/authselect
+issue_repository: https://github.com/authselect/authselect
+
+upstream_package_name: authselect
+specfile_path: authselect.spec
+
+actions:
+  post-upstream-clone:
+    # generate spec file from template
+    - bash -c "sed -E 's/@\w+@/0/g' rpm/authselect.spec.in > authselect.spec"
+
+jobs:
+  - job: copr_build
+    trigger: pull_request
+    # waiting for https://github.com/packit/packit-service/issues/2431
+    #owner: @authselect
+    targets:
+      - fedora-all
+      - epel-9
+      - epel-8
+
+  - job: propose_downstream
+    trigger: release
+    dist_git_branches:
+      - fedora-rawhide
+
+  - job: koji_build
+    trigger: commit
+    dist_git_branches:
+      - fedora-rawhide


### PR DESCRIPTION
Hello @pbrezina, I'm opening this PR in response to https://github.com/packit/packit-service/issues/2372.

Packit configuration I've added includes both upstream and downstream jobs.

As for upstream, there is a `copr_build` job that builds authselect in Copr in the specified chroots on every pull request. You can see the results [here](https://github.com/nforro/authselect/pull/1/checks) on my fork. To enable it in this repository, please follow our [onboarding guide](https://packit.dev/docs/guide#how-to-set-up-packit-on-github) and install the *Packit-as-a-Service* GitHub application.

As for downstream, there is a `propose_downstream` job that updates authselect in dist-git when a new GitHub release is published and opens a pull request with the changes. I've only enabled this for rawhide, but it can be configured for stable branches as well. Once the opened dist-git PR is merged, a Koji build is automatically triggered and when finished automatic Bodhi update is created for rawhide.
There are however a few catches here. First, the spec file should be maintained upstream because the one in dist-git would be overwritten on every release. I noticed a few differences between the two, namely the `License` field, but that should be easy to fix. Second, Packit doesn't support downstream patches. Once `propose_downstream` runs, any references to them will be removed from the spec file. Would that be an issue for you?