### PR TITLE
profiles: include "systemd" in shadow + gshadow nsswitch.conf lines

### DIFF
--- a/profiles/local/nsswitch.conf
+++ b/profiles/local/nsswitch.conf
@@ -1,6 +1,6 @@
 # In order of likelihood of use to accelerate lookup.
 passwd:     files {if "with-altfiles":altfiles }systemd
-shadow:     files
+shadow:     files systemd
 group:      files [SUCCESS=merge] {if "with-altfiles":altfiles [SUCCESS=merge] }systemd
 hosts:      files myhostname {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] dns
 services:   files
@@ -9,7 +9,7 @@ automount:  files
 
 aliases:    files
 ethers:     files
-gshadow:    files
+gshadow:    files systemd
 networks:   files dns
 protocols:  files
 publickey:  files

--- a/profiles/nis/nsswitch.conf
+++ b/profiles/nis/nsswitch.conf
@@ -1,6 +1,6 @@
 # In order of likelihood of use to accelerate lookup.
 passwd:     files {if "with-altfiles":altfiles }nis systemd
-shadow:     files nis
+shadow:     files nis systemd
 group:      files [SUCCESS=merge] {if "with-altfiles":altfiles [SUCCESS=merge] }nis [SUCCESS=merge] systemd
 hosts:      files myhostname {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] nis dns
 services:   files nis
@@ -9,7 +9,7 @@ automount:  files nis
 
 aliases:    files nis
 ethers:     files nis
-gshadow:    files nis
+gshadow:    files nis systemd
 networks:   files nis dns
 protocols:  files nis
 publickey:  files nis

--- a/profiles/sssd/nsswitch.conf
+++ b/profiles/sssd/nsswitch.conf
@@ -1,6 +1,6 @@
 # In order of likelihood of use to accelerate lookup.
 passwd:     {if "with-tlog":sss }files {if "with-altfiles":altfiles }{if not "with-tlog":sss }systemd
-shadow:     files
+shadow:     files systemd
 group:      {if "with-tlog":sss [SUCCESS=merge] }files [SUCCESS=merge] {if "with-altfiles":altfiles [SUCCESS=merge] }{if not "with-tlog":sss [SUCCESS=merge] }systemd
 hosts:      files myhostname {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] dns
 services:   files sss
@@ -11,7 +11,7 @@ subid:      sss {include if "with-subid"}
 
 aliases:    files
 ethers:     files
-gshadow:    files
+gshadow:    files systemd
 networks:   files dns
 protocols:  files
 publickey:  files

--- a/profiles/winbind/nsswitch.conf
+++ b/profiles/winbind/nsswitch.conf
@@ -1,6 +1,6 @@
 # In order of likelihood of use to accelerate lookup.
 passwd:     files {if "with-altfiles":altfiles }winbind systemd
-shadow:     files
+shadow:     files systemd
 group:      files [SUCCESS=merge] {if "with-altfiles":altfiles [SUCCESS=merge] }winbind [SUCCESS=merge] systemd
 hosts:      files myhostname {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] dns
 services:   files
@@ -9,7 +9,7 @@ automount:  files
 
 aliases:    files
 ethers:     files
-gshadow:    files
+gshadow:    files systemd
 networks:   files dns
 protocols:  files
 publickey:  files


### PR DESCRIPTION
Since systemd v249 (2021) nss-systemd hasn't just been generating entries in the "passwd" and "group" databases, but in "shadow" and "gshadow" as well. This is documented in the man page:

https://www.freedesktop.org/software/systemd/man/latest/nss-systemd.html

This is generally useful, since various account validity fields that userdb/homed maintains are only exported via spwd/sgrp, but most importantly this makes the "systemd-nspawn --bind-user=" logic work, which just propagates the hashed user pw into a container.

The patch is pretty simple: in all profiles where passwd/group already lists "systemd", we also add it to the lines with shadow/spwd, to the end.