### PR TITLE
sssd: pam_usertype already present in stack earlier

### DIFF
--- a/profiles/sssd/password-auth
+++ b/profiles/sssd/password-auth
@@ -8,7 +8,6 @@ auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregul
 auth        [default=1 ignore=ignore success=ok]         pam_localuser.so
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
 auth        sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
-auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_sss.so forward_pass
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        optional                                     pam_gnome_keyring.so auto_start                        {include if "with-pam-gnome-keyring"}


### PR DESCRIPTION
This appears to remove a duplicate line in the pam stack.  Since `pam_usertype` is already present on line 7 having it again feels odd.