### PR TITLE
configure: fix typo

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -33,8 +33,8 @@ m4_include(src/conf_macros.m4)
 m4_include(external/a2x.m4)
 m4_include(external/po4a.m4)
 
-+dnl Check if functions are present
-+AC_CHECK_FUNCS_ONCE([reallocarray])
+dnl Check if functions are present
+AC_CHECK_FUNCS_ONCE([reallocarray])
 
 dnl Required libraries
 REQUIRE_POPT


### PR DESCRIPTION
Otherwise, it leads to:
```ShellSession
  $ ./configure
  ...
  checking where the gettext function comes from... libc
  ./configure: line 15565: ++ac_func=: command not found
  checking for reallocarray... yes
  ...
```

Fallout from b415003c3868d8b343d8bef4bce804571805e616