### PR TITLE
profiles: merge groups records with [SUCCESS=merge]

### DIFF
--- a/profiles/minimal/nsswitch.conf
+++ b/profiles/minimal/nsswitch.conf
@@ -1,7 +1,7 @@
 aliases:    files                                       {exclude if "with-custom-aliases"}
 automount:  files                                       {exclude if "with-custom-automount"}
 ethers:     files                                       {exclude if "with-custom-ethers"}
-group:      files {if "with-altfiles":altfiles }systemd {exclude if "with-custom-group"}
+group:      files [SUCCESS=merge] {if "with-altfiles":altfiles [SUCCESS=merge] }systemd {exclude if "with-custom-group"}
 hosts:      resolve [!UNAVAIL=return] files myhostname dns {exclude if "with-custom-hosts"}
 initgroups: files                                       {exclude if "with-custom-initgroups"}
 netgroup:   files                                       {exclude if "with-custom-netgroup"}

--- a/profiles/nis/nsswitch.conf
+++ b/profiles/nis/nsswitch.conf
@@ -1,7 +1,7 @@
 aliases:    files nis                   {exclude if "with-custom-aliases"}
 automount:  files nis                   {exclude if "with-custom-automount"}
 ethers:     files nis                   {exclude if "with-custom-ethers"}
-group:      files nis systemd           {exclude if "with-custom-group"}
+group:      files [SUCCESS=merge] nis [SUCCESS=merge] systemd           {exclude if "with-custom-group"}
 hosts:      resolve [!UNAVAIL=return] files nis myhostname dns {exclude if "with-custom-hosts"}
 initgroups: files nis                   {exclude if "with-custom-initgroups"}
 netgroup:   files nis                   {exclude if "with-custom-netgroup"}

--- a/profiles/sssd/nsswitch.conf
+++ b/profiles/sssd/nsswitch.conf
@@ -1,5 +1,5 @@
 passwd:     {if "with-files-domain":sss files|files sss} systemd   {exclude if "with-custom-passwd"}
-group:      {if "with-files-domain":sss files|files sss} systemd   {exclude if "with-custom-group"}
+group:      {if "with-files-domain":sss [SUCCESS=merge] files [SUCCESS=merge]|files [SUCCESS=merge] sss [SUCCESS=merge]} systemd   {exclude if "with-custom-group"}
 netgroup:   sss files           {exclude if "with-custom-netgroup"}
 automount:  sss files           {exclude if "with-custom-automount"}
 services:   sss files           {exclude if "with-custom-services"}

--- a/profiles/winbind/nsswitch.conf
+++ b/profiles/winbind/nsswitch.conf
@@ -1,2 +1,2 @@
 passwd:     files winbind systemd    {exclude if "with-custom-passwd"}
-group:      files winbind systemd    {exclude if "with-custom-group"}
+group:      files [SUCCESS=merge] winbind [SUCCESS=merge] systemd    {exclude if "with-custom-group"}


### PR DESCRIPTION
Services such as systemd-homed would like to advertise users which are
part of system groups, such as "wheel". That only works if glibc's
[SUCCESS=merge] feature is used in nsswitch.conf, so that group records
from multiple sources are merged.

This is documented here:

https://www.freedesktop.org/software/systemd/man/latest/nss-systemd.html#Configuration%20in%20/etc/nsswitch.conf

This hence adds [SUCCESS=merge] expressions to all NSS modules listed in
the "groups" lines.

This is a backport of 8d8adbd35c741d9038588386414ccbddb99bd31d