### PR TITLE
tests: add missing include for stdint

### DIFF
--- a/src/tests/test_common.h
+++ b/src/tests/test_common.h
@@ -36,6 +36,7 @@
 #include <setjmp.h>
 
 #include <stdlib.h>
+#include <stdint.h>
 #include <cmocka.h>
 
 #endif /* _TEST_COMMON_H_ */


### PR DESCRIPTION
Currently, authselect does not build with cmocka 1.1.8, due to missing includes towards `stdint.h`:
```
2025-07-18 14:45:49 make[2]: Leaving directory '/home/lkp/rpmbuild/BUILD/authselect-1.5.0/src/tests'
2025-07-18 14:45:49 In file included from ../../src/tests/test_common.h:39,
2025-07-18 14:45:49                  from test_util_string_array.c:24:
2025-07-18 14:45:49 test_util_string_array.c: In function 'test_string_array_create':
2025-07-18 14:45:49 test_util_string_array.c:32:5: error: 'uintptr_t' undeclared (first use in this function)
2025-07-18 14:45:49    32 |     assert_non_null(array);
2025-07-18 14:45:49       |     ^~~~~~~~~~~~~~~
2025-07-18 14:45:49 test_util_string_array.c:26:1: note: 'uintptr_t' is defined in header '<stdint.h>'; did you forget to '#include <stdint.h>'?
2025-07-18 14:45:49    25 | #include "lib/util/string_array.h"
2025-07-18 14:45:49   +++ |+#include <stdint.h>
2025-07-18 14:45:49    26 | 
2025-07-18 14:45:49 test_util_string_array.c:32:5: note: each undeclared identifier is reported only once for each function it appears in
2025-07-18 14:45:49    32 |     assert_non_null(array);
2025-07-18 14:45:49       |     ^~~~~~~~~~~~~~~
2025-07-18 14:45:49 test_util_string_array.c: In function 'test_string_array_copy__unique_false':
2025-07-18 14:45:49 test_util_string_array.c:47:5: error: 'uintptr_t' undeclared (first use in this function)
2025-07-18 14:45:49    47 |     assert_non_null(array);
2025-07-18 14:45:49       |     ^~~~~~~~~~~~~~~
2025-07-18 14:45:49 test_util_string_array.c:47:5: note: 'uintptr_t' is defined in header '<stdint.h>'; did you forget to '#include <stdint.h>'?
2025-07-18 14:45:49 test_util_string_array.c: In function 'test_string_array_copy__unique_true':
2025-07-18 14:45:49 test_util_string_array.c:90:5: error: 'uintptr_t' undeclared (first use in this function)
2025-07-18 14:45:49    90 |     assert_non_null(array);
```

The attached patch fixed this issue.