### PR TITLE
Skip running apply changes service on read-only `/etc`

### DIFF
--- a/systemd/authselect-apply-changes.service
+++ b/systemd/authselect-apply-changes.service
@@ -3,6 +3,7 @@ Description=Apply authselect changes
 Documentation=man:authselect(8)
 After=local-fs.target
 Before=systemd-user-sessions.service nss-user-lookup.target
+ConditionPathIsReadWrite=/etc
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
This makes a tweak to the `authselect-apply-changes` service configuration so it doesn't start on systems where `/etc` is read-only. Systems that ship with `/etc` read-only have their configuration "baked in", so it does not make sense to attempt to change a configuration that can't be updated (and having a failing service on such systems).

I ran into this issue while working on building a read-only Fedora 43 root filesystem, where the entire root (except for `/var`) is read-only - including `/etc`. On such systems, one currently ends up with a failing `authselect-apply-changes` service.