### PR TITLE
Fix PAM configs when with-systemd-homed feature is enabled

### DIFF
--- a/profiles/local/password-auth
+++ b/profiles/local/password-auth
@@ -3,18 +3,18 @@ auth        required                                     pam_faildelay.so delay=
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
+-auth       [success=done authtok_err=bad perm_denied=bad maxtries=bad default=ignore] pam_systemd_home.so      {include if "with-systemd-homed"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
-auth        sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
-account     sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
+-account    [success=done authtok_expired=bad new_authtok_reqd=bad maxtries=bad acct_expired=bad default=ignore] pam_systemd_home.so {include if "with-systemd-homed"}
 account     required                                     pam_unix.so
 
-password    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
+-password   sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 password    requisite                                    pam_pwquality.so
 password    [default=1 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-pwhistory"}
 password    requisite                                    pam_pwhistory.so use_authtok                           {include if "with-pwhistory"}
@@ -24,7 +24,7 @@ password    required                                     pam_deny.so
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
-session     optional                                     pam_systemd_home.so                                   {include if "with-systemd-homed"}
+-session    optional                                     pam_systemd_home.so                                   {include if "with-systemd-homed"}
 -session    optional                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid

--- a/profiles/local/system-auth
+++ b/profiles/local/system-auth
@@ -4,18 +4,18 @@ auth        required                                     pam_faillock.so preauth
 auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
+-auth       [success=done authtok_err=bad perm_denied=bad maxtries=bad default=ignore] pam_systemd_home.so      {include if "with-systemd-homed"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
-auth        sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
-account     sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
+-account    [success=done authtok_expired=bad new_authtok_reqd=bad maxtries=bad acct_expired=bad default=ignore] pam_systemd_home.so {include if "with-systemd-homed"}
 account     required                                     pam_unix.so
 
-password    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
+-password   sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 password    requisite                                    pam_pwquality.so
 password    [default=1 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-pwhistory"}
 password    requisite                                    pam_pwhistory.so use_authtok                           {include if "with-pwhistory"}
@@ -25,7 +25,7 @@ password    required                                     pam_deny.so
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
-session     optional                                     pam_systemd_home.so                                   {include if "with-systemd-homed"}
+-session    optional                                     pam_systemd_home.so                                   {include if "with-systemd-homed"}
 -session    optional                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid

--- a/profiles/nis/password-auth
+++ b/profiles/nis/password-auth
@@ -3,18 +3,18 @@ auth        required                                     pam_faildelay.so delay=
 auth        required                                     pam_faillock.so preauth silent                           {include if "with-faillock"}
 auth        sufficient                                   pam_u2f.so cue                                           {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
+-auth       [success=done authtok_err=bad perm_denied=bad maxtries=bad default=ignore] pam_systemd_home.so        {include if "with-systemd-homed"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
-auth        sufficient                                   pam_systemd_home.so                                      {include if "with-systemd-homed"}
 auth        required                                     pam_faillock.so authfail                                 {include if "with-faillock"}
 auth        optional                                     pam_gnome_keyring.so only_if=login auto_start            {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                            {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                          {include if "with-faillock"}
-account     sufficient                                   pam_systemd_home.so                                      {include if "with-systemd-homed"}
+-account    [success=done authtok_expired=bad new_authtok_reqd=bad maxtries=bad acct_expired=bad default=ignore] pam_systemd_home.so {include if "with-systemd-homed"}
 account     required                                     pam_unix.so broken_shadow
 
-password    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
+-password   sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 password    requisite                                    pam_pwquality.so {if not "with-nispwquality":local_users_only}
 password    [default=1 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-pwhistory"}
 password    requisite                                    pam_pwhistory.so use_authtok                           {include if "with-pwhistory"}
@@ -24,7 +24,7 @@ password    required                                     pam_deny.so
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                  {include if "with-ecryptfs"}
-session    optional                                      pam_systemd_home.so                                     {include if "with-systemd-homed"}
+-session    optional                                     pam_systemd_home.so                                     {include if "with-systemd-homed"}
 -session    optional                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so                                 {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid

--- a/profiles/nis/system-auth
+++ b/profiles/nis/system-auth
@@ -4,18 +4,18 @@ auth        required                                     pam_faillock.so preauth
 auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
+-auth       [success=done authtok_err=bad perm_denied=bad maxtries=bad default=ignore] pam_systemd_home.so      {include if "with-systemd-homed"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
-auth        sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
 auth        optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}
 auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
-account     sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
+-account    [success=done authtok_expired=bad new_authtok_reqd=bad maxtries=bad acct_expired=bad default=ignore] pam_systemd_home.so {include if "with-systemd-homed"}
 account     required                                     pam_unix.so broken_shadow
 
-password    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
+-password   sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 password    requisite                                    pam_pwquality.so {if not "with-nispwquality":local_users_only}
 password    [default=1 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-pwhistory"}
 password    requisite                                    pam_pwhistory.so use_authtok                           {include if "with-pwhistory"}
@@ -25,7 +25,7 @@ password    required                                     pam_deny.so
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
-session     optional                                     pam_systemd_home.so                                   {include if "with-systemd-homed"}
+-session    optional                                     pam_systemd_home.so                                   {include if "with-systemd-homed"}
 -session    optional                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid

--- a/profiles/sssd/password-auth
+++ b/profiles/sssd/password-auth
@@ -4,10 +4,10 @@ auth        required                                     pam_deny.so # Smartcard
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
+-auth       [success=done authtok_err=bad perm_denied=bad maxtries=bad default=ignore] pam_systemd_home.so      {include if "with-systemd-homed"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        [default=1 ignore=ignore success=ok]         pam_localuser.so
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
-auth        sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_sss.so forward_pass
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
@@ -16,14 +16,14 @@ auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
-account     sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
+-account    [success=done authtok_expired=bad new_authtok_reqd=bad maxtries=bad acct_expired=bad default=ignore] pam_systemd_home.so {include if "with-systemd-homed"}
 account     required                                     pam_unix.so
 account     sufficient                                   pam_localuser.so                                       {exclude if "with-files-access-provider"}
 account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 account     required                                     pam_permit.so
 
-password    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
+-password   sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 password    requisite                                    pam_pwquality.so local_users_only
 password    [default=1 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-pwhistory"}
 password    requisite                                    pam_pwhistory.so use_authtok                           {include if "with-pwhistory"}
@@ -35,7 +35,7 @@ password    required                                     pam_deny.so
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                 {include if "with-ecryptfs"}
-session     optional                                     pam_systemd_home.so                                    {include if "with-systemd-homed"}
+-session    optional                                     pam_systemd_home.so                                    {include if "with-systemd-homed"}
 -session    optional                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so                                {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid

--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -11,8 +11,8 @@ auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregul
 auth        [default=1 ignore=ignore success=ok]         pam_localuser.so                                       {exclude if "with-smartcard"}
 auth        [default=2 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-smartcard"}
 auth        [success=done authinfo_unavail=ignore user_unknown=ignore ignore=ignore default=die] pam_sss.so try_cert_auth {include if "with-smartcard"}
+-auth       [success=done authtok_err=bad perm_denied=bad maxtries=bad default=ignore] pam_systemd_home.so      {include if "with-systemd-homed"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
-auth        sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular                              {include if "with-gssapi"}
 auth        sufficient                                   pam_sss_gss.so                                         {include if "with-gssapi"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
@@ -23,14 +23,14 @@ auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
-account     sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
+-account    [success=done authtok_expired=bad new_authtok_reqd=bad maxtries=bad acct_expired=bad default=ignore] pam_systemd_home.so {include if "with-systemd-homed"}
 account     required                                     pam_unix.so
 account     sufficient                                   pam_localuser.so                                       {exclude if "with-files-access-provider"}
 account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_sss.so
 account     required                                     pam_permit.so
 
-password    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
+-password   sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 password    requisite                                    pam_pwquality.so local_users_only
 password    [default=1 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-pwhistory"}
 password    requisite                                    pam_pwhistory.so use_authtok                           {include if "with-pwhistory"}
@@ -42,7 +42,7 @@ password    required                                     pam_deny.so
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                 {include if "with-ecryptfs"}
-session     optional                                     pam_systemd_home.so                                    {include if "with-systemd-homed"}
+-session    optional                                     pam_systemd_home.so                                    {include if "with-systemd-homed"}
 -session    optional                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so                                {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid

--- a/profiles/winbind/password-auth
+++ b/profiles/winbind/password-auth
@@ -3,8 +3,8 @@ auth        required                                     pam_faildelay.so delay=
 auth        required                                     pam_faillock.so preauth silent                           {include if "with-faillock"}
 auth        sufficient                                   pam_u2f.so cue                                           {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
+-auth       [success=done authtok_err=bad perm_denied=bad maxtries=bad default=ignore] pam_systemd_home.so        {include if "with-systemd-homed"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
-auth        sufficient                                   pam_systemd_home.so                                      {include if "with-systemd-homed"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_first_pass
 auth        required                                     pam_faillock.so authfail                                 {include if "with-faillock"}
@@ -13,14 +13,14 @@ auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                            {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                          {include if "with-faillock"}
-account     sufficient                                   pam_systemd_home.so                                      {include if "with-systemd-homed"}
+-account    [success=done authtok_expired=bad new_authtok_reqd=bad maxtries=bad acct_expired=bad default=ignore] pam_systemd_home.so {include if "with-systemd-homed"}
 account     required                                     pam_unix.so broken_shadow
 account     sufficient                                   pam_localuser.so
 account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_winbind.so {if "with-krb5":krb5_auth}
 account     required                                     pam_permit.so
 
-password    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
+-password   sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 password    requisite                                    pam_pwquality.so local_users_only
 password    [default=1 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-pwhistory"}
 password    requisite                                    pam_pwhistory.so use_authtok                           {include if "with-pwhistory"}
@@ -31,7 +31,7 @@ password    required                                     pam_deny.so
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                  {include if "with-ecryptfs"}
-session     optional                                     pam_systemd_home.so                                     {include if "with-systemd-homed"}
+-session    optional                                     pam_systemd_home.so                                     {include if "with-systemd-homed"}
 -session    optional                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so                                 {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid

--- a/profiles/winbind/system-auth
+++ b/profiles/winbind/system-auth
@@ -4,8 +4,8 @@ auth        required                                     pam_faillock.so preauth
 auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
+-auth       [success=done authtok_err=bad perm_denied=bad maxtries=bad default=ignore] pam_systemd_home.so      {include if "with-systemd-homed"}
 auth        sufficient                                   pam_unix.so {if not "without-nullok":nullok}
-auth        sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 auth        [default=1 ignore=ignore success=ok]         pam_usertype.so isregular
 auth        sufficient                                   pam_winbind.so {if "with-krb5":krb5_auth} use_first_pass
 auth        required                                     pam_faillock.so authfail                               {include if "with-faillock"}
@@ -14,14 +14,14 @@ auth        required                                     pam_deny.so
 
 account     required                                     pam_access.so                                          {include if "with-pamaccess"}
 account     required                                     pam_faillock.so                                        {include if "with-faillock"}
-account     sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
+-account    [success=done authtok_expired=bad new_authtok_reqd=bad maxtries=bad acct_expired=bad default=ignore] pam_systemd_home.so {include if "with-systemd-homed"}
 account     required                                     pam_unix.so broken_shadow
 account     sufficient                                   pam_localuser.so
 account     sufficient                                   pam_usertype.so issystem
 account     [default=bad success=ok user_unknown=ignore] pam_winbind.so {if "with-krb5":krb5_auth}
 account     required                                     pam_permit.so
 
-password    sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
+-password   sufficient                                   pam_systemd_home.so                                    {include if "with-systemd-homed"}
 password    requisite                                    pam_pwquality.so local_users_only
 password    [default=1 ignore=ignore success=ok]         pam_localuser.so                                       {include if "with-pwhistory"}
 password    requisite                                    pam_pwhistory.so use_authtok                           {include if "with-pwhistory"}
@@ -32,7 +32,7 @@ password    required                                     pam_deny.so
 session     optional                                     pam_keyinit.so revoke
 session     required                                     pam_limits.so
 session     optional                                     pam_ecryptfs.so unwrap                                {include if "with-ecryptfs"}
-session     optional                                     pam_systemd_home.so                                   {include if "with-systemd-homed"}
+-session    optional                                     pam_systemd_home.so                                   {include if "with-systemd-homed"}
 -session    optional                                     pam_systemd.so
 session     optional                                     pam_oddjob_mkhomedir.so                               {include if "with-mkhomedir"}
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid


### PR DESCRIPTION
This PR is a fix for issue #428. It modifies the default profiles to use the example PAM config from the [pam_systemd_home man page](https://www.man7.org/linux/man-pages/man8/pam_systemd_home.8.html#EXAMPLE)