### PR TITLE
backup-restore: ignore missing switchable-auth in backup

### DIFF
--- a/src/lib/authselect_backup.c
+++ b/src/lib/authselect_backup.c
@@ -240,17 +240,17 @@ static errno_t
 authselect_restore_system_configuration(const char *path)
 {
     struct selinux_safe_copy table[] = {
-        {FILE_CONFIG,      PATH_CONFIG_FILE, true},
-        {FILE_SYSTEM,      PATH_SYMLINK_SYSTEM, false},
-        {FILE_PASSWORD,    PATH_SYMLINK_PASSWORD, true},
-        {FILE_FINGERPRINT, PATH_SYMLINK_FINGERPRINT, true},
-        {FILE_SMARTCARD,   PATH_SYMLINK_SMARTCARD, true},
-        {FILE_SWITCHABLE,  PATH_SYMLINK_SWITCHABLE, true},
-        {FILE_POSTLOGIN,   PATH_SYMLINK_POSTLOGIN, false},
-        {FILE_NSSWITCH,    PATH_SYMLINK_NSSWITCH, true},
-        {FILE_DCONF_DB,    PATH_SYMLINK_DCONF_DB, true},
-        {FILE_DCONF_LOCK,  PATH_SYMLINK_DCONF_LOCK, true},
-        {NULL, NULL, false},
+        {FILE_CONFIG,      PATH_CONFIG_FILE, true, false},
+        {FILE_SYSTEM,      PATH_SYMLINK_SYSTEM, false, false},
+        {FILE_PASSWORD,    PATH_SYMLINK_PASSWORD, true, false},
+        {FILE_FINGERPRINT, PATH_SYMLINK_FINGERPRINT, true, false},
+        {FILE_SMARTCARD,   PATH_SYMLINK_SMARTCARD, true, false},
+        {FILE_SWITCHABLE,  PATH_SYMLINK_SWITCHABLE, true, false},
+        {FILE_POSTLOGIN,   PATH_SYMLINK_POSTLOGIN, false, false},
+        {FILE_NSSWITCH,    PATH_SYMLINK_NSSWITCH, true, false},
+        {FILE_DCONF_DB,    PATH_SYMLINK_DCONF_DB, true, false},
+        {FILE_DCONF_LOCK,  PATH_SYMLINK_DCONF_LOCK, true, false},
+        {NULL, NULL, false, false},
     };
     errno_t ret;
     int i;
@@ -279,17 +279,17 @@ static errno_t
 authselect_restore_authselect_configuration(const char *path)
 {
     struct selinux_safe_copy table[] = {
-        {FILE_CONFIG,      PATH_CONFIG_FILE, false},
-        {FILE_SYSTEM,      PATH_SYSTEM, false},
-        {FILE_PASSWORD,    PATH_PASSWORD, false},
-        {FILE_FINGERPRINT, PATH_FINGERPRINT, false},
-        {FILE_SMARTCARD,   PATH_SMARTCARD, false},
-        {FILE_SWITCHABLE,  PATH_SWITCHABLE, false},
-        {FILE_POSTLOGIN,   PATH_POSTLOGIN, false},
-        {FILE_NSSWITCH,    PATH_NSSWITCH, false},
-        {FILE_DCONF_DB,    PATH_DCONF_DB, false},
-        {FILE_DCONF_LOCK,  PATH_DCONF_LOCK, false},
-        {NULL, NULL, false},
+        {FILE_CONFIG,      PATH_CONFIG_FILE, false, false},
+        {FILE_SYSTEM,      PATH_SYSTEM, false, false},
+        {FILE_PASSWORD,    PATH_PASSWORD, false, false},
+        {FILE_FINGERPRINT, PATH_FINGERPRINT, false, false},
+        {FILE_SMARTCARD,   PATH_SMARTCARD, false, false},
+        {FILE_SWITCHABLE,  PATH_SWITCHABLE, false, true},
+        {FILE_POSTLOGIN,   PATH_POSTLOGIN, false, false},
+        {FILE_NSSWITCH,    PATH_NSSWITCH, false, false},
+        {FILE_DCONF_DB,    PATH_DCONF_DB, false, false},
+        {FILE_DCONF_LOCK,  PATH_DCONF_LOCK, false, false},
+        {NULL, NULL, false, false},
     };
     errno_t ret;
     int i;

--- a/src/lib/files/symlinks.c
+++ b/src/lib/files/symlinks.c
@@ -163,16 +163,16 @@ errno_t
 authselect_symlinks_uninstall()
 {
     struct selinux_safe_copy table[] = {
-        {PATH_SYSTEM,      PATH_SYMLINK_SYSTEM, false},
-        {PATH_PASSWORD,    PATH_SYMLINK_PASSWORD, false},
-        {PATH_FINGERPRINT, PATH_SYMLINK_FINGERPRINT, false},
-        {PATH_SMARTCARD,   PATH_SYMLINK_SMARTCARD, false},
-        {PATH_SWITCHABLE,  PATH_SYMLINK_SWITCHABLE, false},
-        {PATH_POSTLOGIN,   PATH_SYMLINK_POSTLOGIN, false},
-        {PATH_NSSWITCH,    PATH_SYMLINK_NSSWITCH, false},
-        {PATH_DCONF_DB,    PATH_SYMLINK_DCONF_DB, false},
-        {PATH_DCONF_LOCK,  PATH_SYMLINK_DCONF_LOCK, false},
-        {NULL, NULL, false}
+        {PATH_SYSTEM,      PATH_SYMLINK_SYSTEM, false, false},
+        {PATH_PASSWORD,    PATH_SYMLINK_PASSWORD, false, false},
+        {PATH_FINGERPRINT, PATH_SYMLINK_FINGERPRINT, false, false},
+        {PATH_SMARTCARD,   PATH_SYMLINK_SMARTCARD, false, false},
+        {PATH_SWITCHABLE,  PATH_SYMLINK_SWITCHABLE, false, false},
+        {PATH_POSTLOGIN,   PATH_SYMLINK_POSTLOGIN, false, false},
+        {PATH_NSSWITCH,    PATH_SYMLINK_NSSWITCH, false, false},
+        {PATH_DCONF_DB,    PATH_SYMLINK_DCONF_DB, false, false},
+        {PATH_DCONF_LOCK,  PATH_SYMLINK_DCONF_LOCK, false, false},
+        {NULL, NULL, false, false}
     };
     errno_t ret;
     bool result;

--- a/src/lib/util/selinux.h
+++ b/src/lib/util/selinux.h
@@ -86,6 +86,9 @@ struct selinux_safe_copy {
 
     /* Unlink destination if source file does not exist. */
     bool can_unlink;
+
+    /* Write an empty file if the source is missing. */
+    bool write_empty_if_missing;
 };
 
 /**


### PR DESCRIPTION
This is a new file and it can be missing from the backup. In this case
we will just write an empty file. This is a corner case, an empty file
will not break system authentication so this is fine.

https://bodhi.fedoraproject.org/updates/FEDORA-2026-8a3906ef4b#comment-4516638
