### PR TITLE
profiles: add support for oddjob-gpupdate to SSSD

### DIFF
--- a/profiles/sssd/README
+++ b/profiles/sssd/README
@@ -132,6 +132,11 @@ with-switchable-auth::
     to select the authentication method that shall be used to authenticate the
     user.
 
+with-gpupdate::
+    Enable automatic application of Samba Group Policy Objects (GPOs) on user
+    login through oddjob-gpupdate. This allows SSSD-based systems to apply
+    GPOs (sudo rules, banners, files, browser policies) similar to winbind.
+
 EXAMPLES
 --------
 

--- a/profiles/sssd/REQUIREMENTS
+++ b/profiles/sssd/REQUIREMENTS
@@ -31,3 +31,7 @@ Make sure that SSSD service is configured and enabled. See SSSD documentation fo
                                                                                           {include if "with-switchable-auth"}
 - with-switchable-auth is selected, make sure to enable it in sssd.conf                   {include if "with-switchable-auth"}
   - set "pam_json_services = list-of-services" in [pam] section                           {include if "with-switchable-auth"}
+                                                                                          {include if "with-gpupdate"}
+- with-gpupdate is selected, make sure pam_oddjob_gpupdate module                         {include if "with-gpupdate"}
+  and samba-gpupdate are present and oddjobd service is enabled and active                {include if "with-gpupdate"}
+  - systemctl enable --now oddjobd.service                                                {include if "with-gpupdate"}

--- a/profiles/sssd/fingerprint-auth
+++ b/profiles/sssd/fingerprint-auth
@@ -26,4 +26,5 @@ session     optional                                     pam_oddjob_mkhomedir.so
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
 session     optional                                     pam_sss.so
+session     optional                                     pam_oddjob_gpupdate.so                                 {include if "with-gpupdate"}
 session     optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}

--- a/profiles/sssd/password-auth
+++ b/profiles/sssd/password-auth
@@ -41,4 +41,5 @@ session     optional                                     pam_oddjob_mkhomedir.so
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
 session     optional                                     pam_sss.so
+session     optional                                     pam_oddjob_gpupdate.so                                 {include if "with-gpupdate"}
 session     optional                                     pam_gnome_keyring.so auto_start                        {include if "with-pam-gnome-keyring"}

--- a/profiles/sssd/smartcard-auth
+++ b/profiles/sssd/smartcard-auth
@@ -24,4 +24,5 @@ session     optional                                     pam_oddjob_mkhomedir.so
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
 session     optional                                     pam_sss.so
+session     optional                                     pam_oddjob_gpupdate.so                                 {include if "with-gpupdate"}
 session     optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}

--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -48,4 +48,5 @@ session     optional                                     pam_oddjob_mkhomedir.so
 session     [success=1 default=ignore]                   pam_succeed_if.so service in crond quiet use_uid
 session     required                                     pam_unix.so
 session     optional                                     pam_sss.so
+session     optional                                     pam_oddjob_gpupdate.so                                 {include if "with-gpupdate"}
 session     optional                                     pam_gnome_keyring.so only_if=login auto_start          {include if "with-pam-gnome-keyring"}


### PR DESCRIPTION
Samba for a while now included support for applying basic GPOs (sudo rules, banner, files, browser policies, etc.) to Linux machines via `samba-gpupdate`.

Usually applying them automatically is only supported when using winbind as the auth mechanism since it includes this built in. Alt linux, which includes their own gpo tool, has created `oddjob-gpupdate` in order to allow this functionality to be used with SSSD instead.

Originally OpenSUSE forked `oddjob-gpupdate` and made it compatible with the `samba-gpupdate` mechanism. This package is now also included in Fedora. Yet there has been no easy way to configure its PAM module since authselect does not include it in its SSSD profile.

This adds support for the `with-gpupdate` feature which relies on this module to allow group policies to be automatically applied when using SSSD. 

I placed the PAM module after SSSD since AFAIK samba-gpupdate should run as late as possible but before the GNOME keyring (if included) since samba includes GPOs that might change GNOME settings. However if anybody thinks there is a more logical order I'm obviously willing to make changes.