### PR TITLE
profiles: add with-group-merging feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,3 +160,186 @@ jobs:
           install.log
           pytest.log
           pytest-collect.log
+
+  ostree:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        path: authselect
+
+    - name: Setup containers
+      uses: SSSD/sssd-ci-containers/actions/setup@master
+      with:
+        path: sssd-ci-containers
+        tag: rawhide
+        override: |
+          services:
+            client:
+              image: ${REGISTRY}/ci-client-devel:${TAG}
+              shm_size: 4G
+              tmpfs:
+              - /dev/shm
+              volumes:
+              - ../authselect:/authselect:rw
+
+    - name: Create ostree marker (mimic required ostree detection)
+      uses: SSSD/sssd-ci-containers/actions/exec@master
+      with:
+        user: root
+        where: client
+        script: |
+          #!/bin/bash
+          set -ex
+          mkdir -p /run
+          touch /run/ostree-booted
+
+    - name: Install build dependencies on the client
+      uses: SSSD/sssd-ci-containers/actions/exec@master
+      with:
+        log-file: ostree-dependencies.log
+        working-directory: /authselect
+        user: root
+        where: client
+        script: |
+          #!/bin/bash
+          set -ex
+
+          scripts/auto install-build-deps
+
+    - name: Build authselect RPMs on the client
+      uses: SSSD/sssd-ci-containers/actions/exec@master
+      with:
+        log-file: ostree-build.log
+        working-directory: /authselect
+        where: client
+        script: |
+          #!/bin/bash
+          set -ex
+          autoreconf -if && ./configure --enable-silent-rules
+          make rpms
+
+    - name: Install authselect RPMs on the client
+      uses: SSSD/sssd-ci-containers/actions/exec@master
+      with:
+        log-file: ostree-install.log
+        working-directory: /authselect
+        user: root
+        where: client
+        script: |
+          #!/bin/bash
+          set -ex
+          dnf install -y rpmbuild/RPMS/*/*.rpm
+
+    - name: Verify that vendor profiles were created
+      uses: SSSD/sssd-ci-containers/actions/exec@master
+      with:
+        log-file: ostree-verify-vendor.log
+        user: root
+        where: client
+        script: |
+          #!/bin/bash
+          set -ex
+
+          # Check that vendor profiles directory exists
+          test -d /usr/share/authselect/vendor
+
+          # Check that vendor profiles were created for each default profile
+          for profile in sssd winbind nis local; do
+            if [ -d "/usr/share/authselect/default/$profile" ]; then
+              echo "Checking vendor profile: $profile"
+              test -d "/usr/share/authselect/vendor/$profile" || {
+                echo "ERROR: Vendor profile $profile not found"
+                exit 1
+              }
+
+              # Verify nsswitch.conf exists in vendor profile
+              nsswitch="/usr/share/authselect/vendor/$profile/nsswitch.conf"
+              test -f "$nsswitch" || {
+                echo "ERROR: nsswitch.conf not found in vendor/$profile"
+                exit 1
+              }
+
+              # Verify "with-altfiles" template conditional was removed
+              if grep -q "with-altfiles" "$nsswitch"; then
+                echo "ERROR: 'with-altfiles' template conditional still present in $nsswitch"
+                cat "$nsswitch"
+                exit 1
+              fi
+
+              echo "Vendor profile $profile: OK (with-altfiles conditional removed)"
+            fi
+          done
+
+    - name: Verify altfiles is enabled in /etc/nsswitch.conf
+      uses: SSSD/sssd-ci-containers/actions/exec@master
+      with:
+        log-file: ostree-verify-altfiles.log
+        user: root
+        where: client
+        script: |
+          #!/bin/bash
+          set -ex
+
+          echo "Checking /etc/nsswitch.conf for altfiles..."
+          cat /etc/nsswitch.conf
+
+          # Check altfiles is present on passwd: line
+          if ! grep "^passwd:" /etc/nsswitch.conf | grep -q "altfiles"; then
+            echo "ERROR: 'altfiles' not found on passwd: line in /etc/nsswitch.conf"
+            exit 1
+          fi
+
+          # Check altfiles is present on group: line
+          if ! grep "^group:" /etc/nsswitch.conf | grep -q "altfiles"; then
+            echo "ERROR: 'altfiles' not found on group: line in /etc/nsswitch.conf"
+            exit 1
+          fi
+
+          echo "SUCCESS: altfiles present on passwd: and group: lines in /etc/nsswitch.conf"
+
+    - name: Verify altfiles is enabled with with-group-merging /etc/nsswitch.conf
+      uses: SSSD/sssd-ci-containers/actions/exec@master
+      with:
+        log-file: ostree-verify-altfiles-after.log
+        user: root
+        where: client
+        script: |
+          #!/bin/bash
+          set -ex
+
+          authselect enable-feature with-group-merging
+
+          echo "Checking /etc/nsswitch.conf for altfiles after enabling with-group-merging..."
+          cat /etc/nsswitch.conf
+
+          # Check altfiles is present on passwd: line
+          if ! grep "^passwd:" /etc/nsswitch.conf | grep -q "altfiles"; then
+            echo "ERROR: 'altfiles' not found on passwd: line in /etc/nsswitch.conf after feature change"
+            exit 1
+          fi
+
+          # Check altfiles is present on group: line
+          if ! grep "^group:" /etc/nsswitch.conf | grep -q "altfiles"; then
+            echo "ERROR: 'altfiles' not found on group: line in /etc/nsswitch.conf after feature change"
+            exit 1
+          fi
+
+          echo "SUCCESS: altfiles still present on passwd: and group: lines in /etc/nsswitch.conf after feature change"
+
+    - name: Upload artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        if-no-files-found: ignore
+        name: ostree
+        path: |
+          ostree-dependencies.log
+          ostree-build.log
+          ostree-install.log
+          ostree-verify-vendor.log
+          ostree-verify-altfiles.log
+          ostree-verify-altfiles-after.log

--- a/profiles/local/README
+++ b/profiles/local/README
@@ -51,6 +51,11 @@ with-pwhistory::
 with-altfiles::
     Use nss_altfiles for passwd and group nsswitch databases.
 
+with-group-merging::
+    Enable merging of group records from multiple NSS sources using
+    [SUCCESS=merge]. Required for services like systemd-homed that
+    advertise users as part of system groups.
+
 with-mdns4::
     Enable multicast DNS over IPv4.
 

--- a/profiles/local/nsswitch.conf
+++ b/profiles/local/nsswitch.conf
@@ -1,7 +1,8 @@
 # In order of likelihood of use to accelerate lookup.
 passwd:     files {if "with-altfiles":altfiles }systemd
 shadow:     files systemd
-group:      files [SUCCESS=merge] {if "with-altfiles":altfiles [SUCCESS=merge] }systemd
+group:      files {if "with-altfiles":altfiles }systemd {exclude if "with-group-merging"}
+group:      files [SUCCESS=merge] {if "with-altfiles":altfiles [SUCCESS=merge] }systemd [SUCCESS=merge] {include if "with-group-merging"}
 hosts:      files myhostname {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] dns
 services:   files
 netgroup:   files

--- a/profiles/nis/README
+++ b/profiles/nis/README
@@ -62,6 +62,11 @@ with-nispwquality::
 with-altfiles::
     Use nss_altfiles for passwd and group nsswitch databases.
 
+with-group-merging::
+    Enable merging of group records from multiple NSS sources using
+    [SUCCESS=merge]. Required for services like systemd-homed that
+    advertise users as part of system groups.
+
 with-mdns4::
     Enable multicast DNS over IPv4.
 

--- a/profiles/nis/nsswitch.conf
+++ b/profiles/nis/nsswitch.conf
@@ -1,7 +1,8 @@
 # In order of likelihood of use to accelerate lookup.
 passwd:     files {if "with-altfiles":altfiles }nis systemd
 shadow:     files nis systemd
-group:      files [SUCCESS=merge] {if "with-altfiles":altfiles [SUCCESS=merge] }nis [SUCCESS=merge] systemd
+group:      files {if "with-altfiles":altfiles }nis systemd {exclude if "with-group-merging"}
+group:      files [SUCCESS=merge] {if "with-altfiles":altfiles [SUCCESS=merge] }nis [SUCCESS=merge] systemd [SUCCESS=merge] {include if "with-group-merging"}
 hosts:      files myhostname {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] nis dns
 services:   files nis
 netgroup:   files nis

--- a/profiles/sssd/README
+++ b/profiles/sssd/README
@@ -86,6 +86,11 @@ with-pwhistory::
 with-altfiles::
     Use nss_altfiles for passwd and group nsswitch databases.
 
+with-group-merging::
+    Enable merging of group records from multiple NSS sources using
+    [SUCCESS=merge]. Required for services like systemd-homed that
+    advertise users as part of system groups.
+
 with-mdns4::
     Enable multicast DNS over IPv4.
 

--- a/profiles/sssd/nsswitch.conf
+++ b/profiles/sssd/nsswitch.conf
@@ -1,7 +1,8 @@
 # In order of likelihood of use to accelerate lookup.
 passwd:     {if "with-tlog":sss }files {if "with-altfiles":altfiles }{if not "with-tlog":sss }systemd
 shadow:     files systemd
-group:      {if "with-tlog":sss [SUCCESS=merge] }files [SUCCESS=merge] {if "with-altfiles":altfiles [SUCCESS=merge] }{if not "with-tlog":sss [SUCCESS=merge] }systemd
+group:      {if "with-tlog":sss }files {if "with-altfiles":altfiles }{if not "with-tlog":sss }systemd {exclude if "with-group-merging"}
+group:      {if "with-tlog":sss [SUCCESS=merge] }files [SUCCESS=merge] {if "with-altfiles":altfiles [SUCCESS=merge] }{if not "with-tlog":sss [SUCCESS=merge] }systemd [SUCCESS=merge] {include if "with-group-merging"}
 hosts:      files myhostname {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] dns
 services:   files sss
 netgroup:   files sss

--- a/profiles/winbind/README
+++ b/profiles/winbind/README
@@ -72,6 +72,11 @@ with-pwhistory::
 with-altfiles::
     Use nss_altfiles for passwd and group nsswitch databases.
 
+with-group-merging::
+    Enable merging of group records from multiple NSS sources using
+    [SUCCESS=merge]. Required for services like systemd-homed that
+    advertise users as part of system groups.
+
 with-mdns4::
     Enable multicast DNS over IPv4.
 

--- a/profiles/winbind/nsswitch.conf
+++ b/profiles/winbind/nsswitch.conf
@@ -1,7 +1,8 @@
 # In order of likelihood of use to accelerate lookup.
 passwd:     files {if "with-altfiles":altfiles }winbind systemd
 shadow:     files systemd
-group:      files [SUCCESS=merge] {if "with-altfiles":altfiles [SUCCESS=merge] }winbind [SUCCESS=merge] systemd
+group:      files {if "with-altfiles":altfiles }winbind systemd {exclude if "with-group-merging"}
+group:      files [SUCCESS=merge] {if "with-altfiles":altfiles [SUCCESS=merge] }winbind [SUCCESS=merge] systemd [SUCCESS=merge] {include if "with-group-merging"}
 hosts:      files myhostname {if "with-libvirt":libvirt libvirt_guest }{if "with-mdns4" and "with-mdns6":mdns_minimal [NOTFOUND=return] }{if "with-mdns4" and not "with-mdns6":mdns4_minimal [NOTFOUND=return] }{if not "with-mdns4" and "with-mdns6":mdns6_minimal [NOTFOUND=return] }resolve [!UNAVAIL=return] dns
 services:   files
 netgroup:   files

--- a/src/tests/system/tests/test_sssd.py
+++ b/src/tests/system/tests/test_sssd.py
@@ -307,7 +307,7 @@ def test_sssd__nsswitch_conf_group_merging(client: Client, provider: GenericProv
     :setup:
         1. Create local group  and provider group with the same gid
         2. Create and add user to provider group
-        3. Select SSSD authselect profile and start sssd
+        3. Select SSSD authselect profile, enabled with-group-merging and start sssd
     :steps:
         1. Lookup group
         2. Lookup group using only the files service
@@ -318,7 +318,7 @@ def test_sssd__nsswitch_conf_group_merging(client: Client, provider: GenericProv
     """
     client.local.group("group").add(gid=123456)
     provider.group("group").add(gid=123456).add_member(provider.user("user").add())
-    client.authselect.select("sssd")
+    client.authselect.select("sssd", ["with-group-merging"])
     client.sssd.start()
 
     assert "user" in client.tools.getent.group("group").members, "'user' is not a member of the group!"


### PR DESCRIPTION
This also makes group merging disabled by default. Group mergin
is not required by majority of users, but it makes all group lookups
to reach all providers (files, sss, systemd) which may cause performance
issues under some conditions.

It is better to let users who need it to enable it explicitly.
