### PR TITLE
Add feature to prioritise pam_u2f over pam_fprintd

### DIFF
--- a/profiles/local/README
+++ b/profiles/local/README
@@ -30,6 +30,11 @@ with-pam-u2f::
 with-pam-u2f-2fa::
     Enable 2nd factor authentication via u2f dongle through *pam_u2f*.
 
+with-pam-u2f-priority::
+    Prioritize U2F authentication before fingerprint when both
+    with-fingerprint and with-pam-u2f are enabled. This avoids delays
+    when a U2F hardware token is already connected.
+
 without-pam-u2f-nouserok::
     Module argument nouserok is omitted if also with-pam-u2f-2fa is used.
     *WARNING*: Omitting nouserok argument means that users without pam-u2f

--- a/profiles/local/REQUIREMENTS
+++ b/profiles/local/REQUIREMENTS
@@ -19,3 +19,6 @@
                                                                                           {include if "with-pam-u2f-2fa"}
 - with-pam-u2f-2fa is selected, make sure that the pam u2f module is installed            {include if "with-pam-u2f-2fa"}
   - users can then configure keys using the pamu2fcfg tool                                {include if "with-pam-u2f-2fa"}
+                                                                                          {include if "with-pam-u2f-priority"}
+- with-pam-u2f-priority is selected, pam_u2f.so module will take preference over          {include if "with-pam-u2f-priority"}
+  pam_fprintd.so module in system-auth file.                                              {include if "with-pam-u2f-priority"}

--- a/profiles/local/system-auth
+++ b/profiles/local/system-auth
@@ -2,6 +2,7 @@ auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
 auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
+auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f" and "with-pam-u2f-priority"}
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
 -auth       [success=done authtok_err=bad perm_denied=bad maxtries=bad default=ignore] pam_systemd_home.so      {include if "with-systemd-homed"}

--- a/profiles/nis/README
+++ b/profiles/nis/README
@@ -36,6 +36,11 @@ with-pam-u2f::
 with-pam-u2f-2fa::
     Enable 2nd factor authentication via u2f dongle through *pam_u2f*.
 
+with-pam-u2f-priority::
+    Prioritize U2F authentication before fingerprint when both
+    with-fingerprint and with-pam-u2f are enabled. This avoids delays
+    when a U2F hardware token is already connected.
+
 without-pam-u2f-nouserok::
     Module argument nouserok is omitted if also with-pam-u2f-2fa is used.
     *WARNING*: Omitting nouserok argument means that users without pam-u2f

--- a/profiles/nis/REQUIREMENTS
+++ b/profiles/nis/REQUIREMENTS
@@ -19,3 +19,6 @@ Make sure that NIS service is configured and enabled. See NIS documentation for 
                                                                                           {include if "with-systemd-homed"}
 - with-systemd-homed is selected, make sure that the system-homed service is enabled      {include if "with-systemd-homed"}
   - systemctl enable --now systemd-homed.service                                          {include if "with-systemd-homed"}
+                                                                                          {include if "with-pam-u2f-priority"}
+- with-pam-u2f-priority is selected, pam_u2f.so module will take preference over          {include if "with-pam-u2f-priority"}
+  pam_fprintd.so module in system-auth file.                                              {include if "with-pam-u2f-priority"}

--- a/profiles/nis/system-auth
+++ b/profiles/nis/system-auth
@@ -2,6 +2,7 @@ auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
 auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
+auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f" and "with-pam-u2f-priority"}
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
 -auth       [success=done authtok_err=bad perm_denied=bad maxtries=bad default=ignore] pam_systemd_home.so      {include if "with-systemd-homed"}

--- a/profiles/sssd/README
+++ b/profiles/sssd/README
@@ -62,6 +62,11 @@ with-pam-u2f::
 with-pam-u2f-2fa::
     Enable 2nd factor authentication via u2f dongle through *pam_u2f*.
 
+with-pam-u2f-priority::
+    Prioritize U2F authentication before fingerprint when both
+    with-fingerprint and with-pam-u2f are enabled. This avoids delays
+    when a U2F hardware token is already connected.
+
 without-pam-u2f-nouserok::
     Module argument nouserok is omitted if also with-pam-u2f-2fa is used.
     *WARNING*: Omitting nouserok argument means that users without pam-u2f

--- a/profiles/sssd/REQUIREMENTS
+++ b/profiles/sssd/REQUIREMENTS
@@ -35,3 +35,6 @@ Make sure that SSSD service is configured and enabled. See SSSD documentation fo
 - with-gpupdate is selected, make sure pam_oddjob_gpupdate module                         {include if "with-gpupdate"}
   and samba-gpupdate are present and oddjobd service is enabled and active                {include if "with-gpupdate"}
   - systemctl enable --now oddjobd.service                                                {include if "with-gpupdate"}
+                                                                                          {include if "with-pam-u2f-priority"}
+- with-pam-u2f-priority is selected, pam_u2f.so module will take preference over          {include if "with-pam-u2f-priority"}
+  pam_fprintd.so module in system-auth file.                                              {include if "with-pam-u2f-priority"}

--- a/profiles/sssd/system-auth
+++ b/profiles/sssd/system-auth
@@ -4,6 +4,7 @@ auth        required                                     pam_faildelay.so delay=
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
 auth        [success=1 default=ignore]                   pam_succeed_if.so service notin login:gdm:xdm:kdm:kde:xscreensaver:gnome-screensaver:kscreensaver quiet use_uid {include if "with-smartcard-required"}
 auth        [success=done ignore=ignore default=die]     pam_sss.so require_cert_auth ignore_authinfo_unavail   {include if "with-smartcard-required"}
+auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f" and "with-pam-u2f-priority"}
 auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}

--- a/profiles/winbind/README
+++ b/profiles/winbind/README
@@ -48,6 +48,11 @@ with-pam-u2f::
 with-pam-u2f-2fa::
     Enable 2nd factor authentication via u2f dongle through *pam_u2f*.
 
+with-pam-u2f-priority::
+    Prioritize U2F authentication before fingerprint when both
+    with-fingerprint and with-pam-u2f are enabled. This avoids delays
+    when a U2F hardware token is already connected.
+
 without-pam-u2f-nouserok::
     Module argument nouserok is omitted if also with-pam-u2f-2fa is used.
     *WARNING*: Omitting nouserok argument means that users without pam-u2f

--- a/profiles/winbind/REQUIREMENTS
+++ b/profiles/winbind/REQUIREMENTS
@@ -19,3 +19,6 @@ Make sure that winbind service is configured and enabled. See winbind documentat
                                                                                           {include if "with-systemd-homed"}
 - with-systemd-homed is selected, make sure that the system-homed service is enabled      {include if "with-systemd-homed"}
   - systemctl enable --now systemd-homed.service                                          {include if "with-systemd-homed"}
+                                                                                          {include if "with-pam-u2f-priority"}
+- with-pam-u2f-priority is selected, pam_u2f.so module will take preference over          {include if "with-pam-u2f-priority"}
+  pam_fprintd.so module in system-auth file.                                              {include if "with-pam-u2f-priority"}

--- a/profiles/winbind/system-auth
+++ b/profiles/winbind/system-auth
@@ -2,6 +2,7 @@ auth        required                                     pam_env.so
 auth        required                                     pam_faildelay.so delay=2000000
 auth        required                                     pam_faillock.so preauth silent                         {include if "with-faillock"}
 auth        sufficient                                   pam_fprintd.so                                         {include if "with-fingerprint"}
+auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f" and "with-pam-u2f-priority"}
 auth        sufficient                                   pam_u2f.so cue                                         {include if "with-pam-u2f"}
 auth        required                                     pam_u2f.so cue {if not "without-pam-u2f-nouserok":nouserok} {include if "with-pam-u2f-2fa"}
 -auth       [success=done authtok_err=bad perm_denied=bad maxtries=bad default=ignore] pam_systemd_home.so      {include if "with-systemd-homed"}


### PR DESCRIPTION
This patch adds a new optional feature 'with-pam-u2f-priority' that allows users to prioritize U2F hardware token authentication before fingerprint authentication i.e. pam_u2f.so module will be added before pam_fprintd.so module in system-auth file.

Fixes: https://github.com/authselect/authselect/issues/335