### PR TITLE
Update fingerprint authentication condition in dconf-db

### DIFF
--- a/profiles/local/dconf-db
+++ b/profiles/local/dconf-db
@@ -1,4 +1,4 @@
 [org/gnome/login-screen]
 enable-smartcard-authentication=false
-enable-fingerprint-authentication={if "with-fingerprint":true|false}
+enable-fingerprint-authentication={if "with-fingerprint" and not ("with-systemd-homed" or "with-ecryptfs"):true|false}
 enable-switchable-authentication=false

--- a/profiles/local/dconf-locks
+++ b/profiles/local/dconf-locks
@@ -1,3 +1,3 @@
 /org/gnome/login-screen/enable-smartcard-authentication
-/org/gnome/login-screen/enable-fingerprint-authentication
+/org/gnome/login-screen/enable-fingerprint-authentication {include if "with-fingerprint" and not ("with-systemd-homed" or "with-ecryptfs")}
 /org/gnome/login-screen/enable-switchable-authentication


### PR DESCRIPTION
This fixes #462 by ensuring GDM will not attempt to unlock the session with a login pathway that fails to set `PAM_AUTHTOK` if the user's home requires it for decryption.